### PR TITLE
fixed no node.dat file case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0") # no optimization here
 #################### BELOW SPECIFIES COMPILATION FOR SERIAL OR PARALLEL VERSION OF TRIBS ###############################
 
 # set to ON to compile parallel version, set to OFF to compile serial version
-if(ON)
+if(OFF)
     message(WARNING "Compiling parallel version of tRIBS")
 
     target_compile_definitions(${exe}
@@ -177,7 +177,7 @@ else()
 
     target_sources(
             ${exe} PRIVATE src/main.cpp
-            src/Headers/Classrc/ses.h
+            src/Headers/Classes.h
             src/Headers/Definitions.h
             src/Headers/Inclusions.h
             src/Headers/TemplDefinitions.h

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -256,6 +256,9 @@ void tOutput<tSubNode>::ReadNodeOutputList() {
 		Cout<<"\tAttention: The specified file with node IDs does not "
 			<<"exist.\n\t\t   No node output will be written."<<endl<<endl;
 		numNodes = 0;
+        nodeList = nullptr;
+        uzel = nullptr;
+        pixinfo = nullptr;
 		return;
 	}
 	
@@ -852,7 +855,7 @@ tCOutput<tSubNode>::~tCOutput()
 {
 
 	// GMnSKY2008MLE to fix memory leaks
-	if (numOutlets > 0) { 
+	if (numOutlets > 0) {
 		for (int j=0; j < numOutlets; j++) 
 #ifdef PARALLEL_TRIBS
     if ( (Outlets[j] != NULL) && (OutletList[j] > 0) )


### PR DESCRIPTION
defined nodelist, uzel, pixinfo, as nullptr in case where no node.da  files are not provided to avoid malloc error