### PR TITLE
Minor fixes for address/memory allocation errors when using tRIBS in parallel

### DIFF
--- a/src/tGraph/tGraph.cpp
+++ b/src/tGraph/tGraph.cpp
@@ -2167,14 +2167,14 @@ void tGraph::sendInitial() {
       for (il = localFlux[i].begin(); il != localFlux[i].end(); ++il) {
         int soilID = (*il)->getSoilID();
         double vArea = (*il)->getVArea();
-        ndata[d++] = *(reinterpret_cast<double*>(&soilID));
+        ndata[d++] = static_cast<double>(soilID);//*(reinterpret_cast<double*>(&soilID)); //WR debug converts int pointer to double pointer and derefs as double--possible source undefined behavior
         ndata[d++] = vArea;
       }
 
       for (il = upFlow[i].begin(); il != upFlow[i].end(); ++il) {
         int soilID = (*il)->getSoilID();
         double vArea = (*il)->getVArea();
-        ndata[d++] = *(reinterpret_cast<double*>(&soilID));
+        ndata[d++] = static_cast<double>(soilID);//*(reinterpret_cast<double*>(&soilID));//WR debug converts int pointer to double pointer and derefs as double--possible source undefined behavior
         ndata[d++] = vArea;
       }
       tParallel::send(i, INITIAL, ndata, dsizeN);
@@ -2204,13 +2204,13 @@ void tGraph::receiveInitial() {
       std::set<tCNode*>::iterator ir;
       int d = 0;
       for (ir = remoteFlux[i].begin(); ir != remoteFlux[i].end(); ++ir) {
-        int soilID = *(reinterpret_cast<int*>(&ndata[d++]));
+          int soilID = static_cast<int>(ndata[d++]);//int soilID = *(reinterpret_cast<int*>(&ndata[d++]));//WR debug converts double pointer to int pointer and derefs as int--possible source undefined behavior
         (*ir)->setSoilID(soilID);
         (*ir)->setVArea(ndata[d++]);
       }
 
       for (ir = downFlow[i].begin(); ir != downFlow[i].end(); ++ir) {
-        int soilID = *(reinterpret_cast<int*>(&ndata[d++]));
+          int soilID = static_cast<int>(ndata[d++]);// int soilID = *(reinterpret_cast<int*>(&ndata[d++])); //WR debug converts int pointer to double pointer and derefs as int--possible source undefined behavior
         (*ir)->setSoilID(soilID);
         (*ir)->setVArea(ndata[d++]);
       }

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -3173,7 +3173,7 @@ void tEvapoTrans::readHydroMetStat(char *stationfile)
 	readFile >> nParams;
 	
 	weatherStations = new tHydroMet[nStations];
-	assert(weatherStations != 0);
+	assert(weatherStations != nullptr);
 	
 	numStations = nStations;
 	

--- a/src/tSimulator/tRestart.cpp
+++ b/src/tSimulator/tRestart.cpp
@@ -60,8 +60,7 @@ void tRestart<tSubNode>::writeRestart(fstream & rStr)
   balance->writeRestart(rStr);
   hydro->writeRestart(rStr);
   rainfall->writeRestart(rStr);
-  evap->writeRestart(rStr);
-  intercept->writeRestart(rStr);
+  intercept->readRestart(rStr);
   mesh->writeRestart(rStr);
 	// Giuseppe DEBUG Restart 2012 - START 
 	// I have introduced an IF that checks whether
@@ -69,7 +68,10 @@ void tRestart<tSubNode>::writeRestart(fstream & rStr)
 	// are not saved in the binary Restart files.
 	if (snowpack->getSnowOpt() != 0){
 		snowpack->writeRestart(rStr);
-	}// Giuseppe DEBUG Restart 2012 - END
+	}
+    else{
+        evap->writeRestart(rStr);
+    }// Giuseppe DEBUG Restart 2012 - END
 	
 
 }
@@ -88,7 +90,6 @@ void tRestart<tSubNode>::readRestart(fstream & rStr)
 	balance->readRestart(rStr);
 	hydro->readRestart(rStr);
 	rainfall->readRestart(rStr);
-	evap->readRestart(rStr);
 	intercept->readRestart(rStr);
 	mesh->readRestart(rStr);
 	// Giuseppe DEBUG Restart 2012 - START 
@@ -97,7 +98,10 @@ void tRestart<tSubNode>::readRestart(fstream & rStr)
 	// with the writeRestart function.
 	if (snowpack->getSnowOpt() != 0){	
 		snowpack->readRestart(rStr);
-	}// Giuseppe DEBUG Restart 2012 - END
+	}
+    else{
+        evap->readRestart(rStr);
+    }// Giuseppe DEBUG Restart 2012 - END// Giuseppe DEBUG Restart 2012 - END
 }
 
 //=========================================================================


### PR DESCRIPTION
Switched calls of recast to static cast in tGraph and updated tRestart to ignore instances of tEvapoTrans if snowmod =1