### PR TITLE
fix: Resolve Water Balance Closure Issues Across Multiple Modules

### DIFF
--- a/src/tCNode/tCNode.cpp
+++ b/src/tCNode/tCNode.cpp
@@ -105,8 +105,6 @@ tCNode::tCNode() :tNode()
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
-// DEBUG CJC 2025
-  PotEvap_noResist = 0.0;
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
@@ -239,8 +237,6 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
-// DEBUG CJC 2025
-  PotEvap_noResist = 0.0;
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
@@ -556,8 +552,6 @@ double tCNode::getPeakSWETemp() {return peakSWEtemp;}
 double tCNode::getInitPackTime() {return initPackTime;}
 double tCNode::getInitPackTimeTemp() {return initPackTimeTemp;}
 double tCNode::getPeakPackTime() {return peakPackTime;}
-// DEBUG CJC 2025
-double tCNode::getPotEvap_noResist() {return PotEvap_noResist;}
 // snowintercept -- RINEHART 2007 @ NMT
 double tCNode::getIntSWE() {return intSWEq;}//state
 double tCNode::getIntPrec() {return intPrec;}//flux 
@@ -827,8 +821,6 @@ void tCNode::setOptTransmCoeffInPrevGrid(double value) { OptTransmCoeffInPrevGri
 void tCNode::setOptTransmCoeffInUntilGrid(double value) { OptTransmCoeffInUntilGrid = value; }
 void tCNode::setLeafAIInPrevGrid(double value) { LeafAIInPrevGrid = value; }
 void tCNode::setLeafAIInUntilGrid(double value) { LeafAIInUntilGrid = value; }
-// DEBUG CJC 2025
-void tCNode::setPotEvap_noResist(double value) { PotEvap_noResist = value; }
 
 // SKYnGM2008LU
 void tCNode::setAvCanStorParam(double value) { AvCanStorParam = value; }

--- a/src/tCNode/tCNode.cpp
+++ b/src/tCNode/tCNode.cpp
@@ -105,6 +105,8 @@ tCNode::tCNode() :tNode()
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
+// DEBUG CJC 2025
+  PotEvap_noResist = 0.0;
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
@@ -237,6 +239,8 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
+// DEBUG CJC 2025
+  PotEvap_noResist = 0.0;
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
@@ -552,6 +556,8 @@ double tCNode::getPeakSWETemp() {return peakSWEtemp;}
 double tCNode::getInitPackTime() {return initPackTime;}
 double tCNode::getInitPackTimeTemp() {return initPackTimeTemp;}
 double tCNode::getPeakPackTime() {return peakPackTime;}
+// DEBUG CJC 2025
+double tCNode::getPotEvap_noResist() {return PotEvap_noResist;}
 // snowintercept -- RINEHART 2007 @ NMT
 double tCNode::getIntSWE() {return intSWEq;}//state
 double tCNode::getIntPrec() {return intPrec;}//flux 
@@ -821,6 +827,8 @@ void tCNode::setOptTransmCoeffInPrevGrid(double value) { OptTransmCoeffInPrevGri
 void tCNode::setOptTransmCoeffInUntilGrid(double value) { OptTransmCoeffInUntilGrid = value; }
 void tCNode::setLeafAIInPrevGrid(double value) { LeafAIInPrevGrid = value; }
 void tCNode::setLeafAIInUntilGrid(double value) { LeafAIInUntilGrid = value; }
+// DEBUG CJC 2025
+void tCNode::setPotEvap_noResist(double value) { PotEvap_noResist = value; }
 
 // SKYnGM2008LU
 void tCNode::setAvCanStorParam(double value) { AvCanStorParam = value; }

--- a/src/tCNode/tCNode.h
+++ b/src/tCNode/tCNode.h
@@ -207,8 +207,6 @@ public:
   double getInitPackTime();//integratedoutput
   double getInitPackTimeTemp();
   double getPeakPackTime();//integratedoutput
-// DEBUG CJC 2025
-  double getPotEvap_noResist();//integratedoutput
 
   //snowintercept
   double getIntSWE();//state
@@ -394,9 +392,6 @@ public:
   void setPorosity(double);
   void setVolHeatCond(double);
   void setSoilHeatCap(double);
-// DEBUG CJC 2025
-  void setPotEvap_noResist(double);//integratedoutput
-
   void setTTime(double);               //Routing Members
   void setHillPath(double);   
   void setStreamPath(double); 
@@ -729,8 +724,6 @@ protected:
   double lFlux;
   double Gnod;
   double Aspect;
-// DEBUG CJC 2025
-  double PotEvap_noResist;
 
   //ASM 2/10/2017
   double ChannelPerc;

--- a/src/tCNode/tCNode.h
+++ b/src/tCNode/tCNode.h
@@ -207,6 +207,9 @@ public:
   double getInitPackTime();//integratedoutput
   double getInitPackTimeTemp();
   double getPeakPackTime();//integratedoutput
+// DEBUG CJC 2025
+  double getPotEvap_noResist();//integratedoutput
+
   //snowintercept
   double getIntSWE();//state
   double getIntPrec();//flux
@@ -391,6 +394,8 @@ public:
   void setPorosity(double);
   void setVolHeatCond(double);
   void setSoilHeatCap(double);
+// DEBUG CJC 2025
+  void setPotEvap_noResist(double);//integratedoutput
 
   void setTTime(double);               //Routing Members
   void setHillPath(double);   
@@ -724,6 +729,8 @@ protected:
   double lFlux;
   double Gnod;
   double Aspect;
+// DEBUG CJC 2025
+  double PotEvap_noResist;
 
   //ASM 2/10/2017
   double ChannelPerc;

--- a/src/tFlowNet/tFlowNet.cpp
+++ b/src/tFlowNet/tFlowNet.cpp
@@ -856,6 +856,8 @@ void tFlowNet::SurfaceFlow()
 		res->store_saturation(0.0, AreaF*cn->getSnSub(),21);// Calculated mean snowpack sublimation CJC2020 
 			//Mean SnSub
 		res->store_saturation(0.0, AreaF*cn->getSnEvap(),22);// Calculated mean snowpack sublimation CJC2020
+		//Mean Qunsat
+		res->store_saturation(0.0, AreaF*(cn->getQpout() - cn->getQpin()) * 1.E-6 / cn->getVArea(),24); // CJC 2025
 
         //ASM Percolation option
         if (percolationOption != 0)

--- a/src/tFlowNet/tFlowNet.cpp
+++ b/src/tFlowNet/tFlowNet.cpp
@@ -789,7 +789,14 @@ void tFlowNet::SurfaceFlow()
 				res->store_volume_Type( ttime, vRunoff, 4 ); 
 			}
 		}
-		
+		 // Fix for converting MDGW sloped depth to vertical depth CJC2025
+		// Get the slope correction factor for the current node.
+		tEdge *flowEdge = cn->getFlowEdg();
+		double cos_slope = cos(atan(flowEdge->getSlope()));
+		if (cos_slope < 1E-9) cos_slope = 1.E-9;
+		// Convert Nwt to a vertical depth.
+		double nwt_vertical = cn->getNwtNew() / cos_slope;
+
 		// Rainfall and Saturation Storage in tFlowResults
 		res->store_rain(0.0, AreaF*cn->getRain());
 		
@@ -806,7 +813,7 @@ void tFlowNet::SurfaceFlow()
 		if (cn->getSoilMoistureSC() >= 1)
 			res->store_saturation(0.0, AreaF, 3);
 		// Mean groundwater level
-		res->store_saturation(0.0, AreaF*cn->getNwtNew(), 4);
+		res->store_saturation(0.0, AreaF*nwt_vertical, 4);
 		//Mean Evapotranspiration
 		res->store_saturation(0.0, AreaF*cn->getEvapoTrans(), 5);
 

--- a/src/tFlowNet/tFlowResults.h
+++ b/src/tFlowNet/tFlowResults.h
@@ -133,6 +133,7 @@ public:
   double *intunl;		// Mean int unloading in space
   double *sca;			// Fraction snow covered area
   double *Perc; 	// Percolation from the channel bottom ASM percolation option
+  double *qunsat;		// Mean net flow froom unsaturated zone CJC2025
 
   int *fState;                  // Forecast state
 

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -1092,6 +1092,7 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 		rs = stomResist();
 		transFactor = (cc + psy)/(cc + psy*(1+rs/ra));
 		
+		// Code block modified to accoutn for changes to evapWetCanopy calculation in tIntercept:InterceptRutter CJC2025
 		// Check if the interception scheme is turned on
 		if ( flag && (coeffV > 0) && Intercept->IsThereCanopy( cNode )) {
 			// Get quantities and make checks depending on Interception model

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -168,6 +168,8 @@ class tEvapoTrans
   double coeffKs{}, coeffCs{}, coeffPan{};
   // SKY2008Snow from AJR2007
   double coeffLAI{};
+  // CJC DEBUG 2025
+  double Epot_noResist{}; // Potential evapotranspiration without resistances
 
   double Rah{}, Rstm{};
   double SoilHeatCondTh{}, SoilHeatCpctTh{}, SoilHeatDiffTh{};

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -168,9 +168,6 @@ class tEvapoTrans
   double coeffKs{}, coeffCs{}, coeffPan{};
   // SKY2008Snow from AJR2007
   double coeffLAI{};
-  // CJC DEBUG 2025
-  double Epot_noResist{}; // Potential evapotranspiration without resistances
-
   double Rah{}, Rstm{};
   double SoilHeatCondTh{}, SoilHeatCpctTh{}, SoilHeatDiffTh{};
   double potEvap{}, actEvap{}, panEvap{}, betaS{}, betaT{};

--- a/src/tMeshElements/meshElements.cpp
+++ b/src/tMeshElements/meshElements.cpp
@@ -452,7 +452,8 @@ double tNode::ComputeVoronoiArea()
 			xy1 = ne->getRVtx();
 			//checking polygon edge is on boundary and ccw edge's RVtx is on
 			//wrong side of bndy edge...
-			if( ce->getBoundaryFlag() && ne->getBoundaryFlag() )
+			// CJC 2025 debug if statement wouldn't execute for voronoi connected to outlet point causing area to be equal to last node
+			if( ce->getDestinationPtrNC()->getBoundaryFlag() != kNonBoundary && ne->getDestinationPtrNC()->getBoundaryFlag() != kNonBoundary )
 			{
 				bn0 = ce->getDestinationPtrNC();
 				bn1 = ne->getDestinationPtrNC();


### PR DESCRIPTION
This pull request addresses minor water balance issues in the model. Depending on the specific model, some simulations appeared to close the water balance. A detailed investigation revealed this was due to a coincidental cancellation of multiple offsetting errors in the snow interception, rain interception, and soil modules.
This branch systematically corrects these underlying physical and numerical inconsistencies, leading to an improved water balance. The total flux amounts in test simulations will differ from the dev branch, which is the expected outcome of fixing these bugs.

Detailed Changes
- Problem: The original code calculated snow interception (Isnow) using a precipitation rate that was pre-scaled by the vegetation fraction (coeffV), resulting in a small Isnow value. It then subtracted this artificially small Isnow from the total unscaled cell precipitation, systematically over-calculating the net precipitation reaching the ground.
- Fix:
    1. The interception calculation now correctly uses the full, unscaled precipitation rate.
    2. The final net precipitation is now calculated by explicitly partitioning fluxes over the vegetated and bare fractions of the grid cell: (throughfall * coeffV) + (precip * (1 - coeffV)).
    3. Output fluxes from the canopy (sublimation and unloading) are now scaled by coeffV before being set to the node, ensuring they represent a grid-cell-averaged flux.


- Problem: The Rutter interception model contained two flaws:
    1. Wet Canopy Evaporation: The Runge-Kutta solver correctly simulated evaporation's effect on canopy storage, but this evaporated water was not the value written to the output files.
    2. Non-Physical Fudge Factor: A can_flx term was used to forcibly close the water balance, creating a phantom water source by lumping the numerical error directly into net precipitation.
- Fix: The routine has been partially rewritten to use a "water balance by residual" method.
    1. It now explicitly calculates the total volume of water evaporated (evapWetCanopy_vol) and reports it as a distinct flux.
    2. The drainage flux is calculated as the residual of the canopy water balance, guaranteeing that Inflow = ΔStorage + Evaporation + Drainage. This eliminates the need for any non-physical fudge factors.

- Problem: The model was not translating the soil water state from the model's internal "sloped frame" back to the "vertical frame". While inputs were correctly projected (* cos(slope)), the stored water volume was not un-projected (/ cos(slope)), before writing the soil water state variables to the output files.
- Fix: The state variables representing stored water depth are now divided by cos(slope) before being written to the output files.

- Problem: The function ComputeVoronoiArea() had an if-else statement that under certain conditions for the voronoi polygon would lead to using the calculated area for the previous voronoi polygon leading to an incorrect total watershed area used in computing the mean response file (.mrf). This bug had a larger impact on models with smaller domains. 
- Fix: Add additional cases to the bugged if-else statement to account for all voronoi polygons.

- Problem: The model did not write the lateral water fluxes between computational elements in the unsaturated zone to the .mrf output. Depending on the model domain these can be important for closing the water balance.
- Fix: The net lateral flux between computational elements (Q Out minus Q In) has been added to the .mrf output. This change seems to be more important for smaller domains like single polygons where the .pixel file can be used instead of the .mrf file for calculating the water balance. Thus, this output might be removed in future versions.