### PR TITLE
feat: Add gridded stress thresholds and fix step-wise LU updates

### DIFF
--- a/src/tCNode/tCNode.cpp
+++ b/src/tCNode/tCNode.cpp
@@ -97,6 +97,7 @@ tCNode::tCNode() :tNode()
 	IntercepCoeff = CanFieldCap = DrainCoeff = 0.0;  
 	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;	
 	CanStorParam = 0.0;
+  EvapThresh = TransThresh = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
@@ -105,11 +106,13 @@ tCNode::tCNode() :tNode()
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
+  EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
+  AvEvapThresh = AvTransThresh = 0.0; // CJC2025
 	
 	// SKY2008Snow from AJR2007
 	//snowpack -- RINEHART 2007 @ NMT
@@ -229,6 +232,7 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	IntercepCoeff = CanFieldCap = DrainCoeff = 0.0; 
 	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;
         CanStorParam = 0.0;	
+  EvapThresh = TransThresh = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
@@ -237,11 +241,13 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
+  EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
+  AvEvapThresh = AvTransThresh = 0.0; // CJC2025
 
 	// SKY2008Snow from AJR2007
 	//snowpack -- RINEHART 2007 @ NMT
@@ -459,6 +465,9 @@ double tCNode::getDrainExpPar() {return DrainExpPar;}
 double tCNode::getOptTransmCoeff() {return OptTransmCoeff;}
 double tCNode::getLeafAI() {return LeafAI;}
 double tCNode::getCanStorParam() {return CanStorParam;}
+// CJC2025: New Parameters
+double tCNode::getEvapThresh() {return EvapThresh;}
+double tCNode::getTransThresh() {return TransThresh;}
 
 // SKYnGM2008LU
 double tCNode::getLandUseAlbInPrevGrid() {return LandUseAlbInPrevGrid;}
@@ -485,6 +494,11 @@ double tCNode::getOptTransmCoeffInPrevGrid() {return OptTransmCoeffInPrevGrid;}
 double tCNode::getOptTransmCoeffInUntilGrid() {return OptTransmCoeffInUntilGrid;}
 double tCNode::getLeafAIInPrevGrid() {return LeafAIInPrevGrid;}
 double tCNode::getLeafAIInUntilGrid() {return LeafAIInUntilGrid;}
+// CJC2025: New Parameters
+double tCNode::getEvapThreshInPrevGrid() {return EvapThreshInPrevGrid;} 
+double tCNode::getEvapThreshInUntilGrid() {return EvapThreshInUntilGrid;} 
+double tCNode::getTransThreshInPrevGrid() {return TransThreshInPrevGrid;} 
+double tCNode::getTransThreshInUntilGrid() {return TransThreshInUntilGrid;} 
 
 // SKYnGM2008LU
 double tCNode::getAvCanStorParam() {return AvCanStorParam;}
@@ -499,6 +513,9 @@ double tCNode::getAvOptTransmCoeff() {return AvOptTransmCoeff;}
 double tCNode::getAvStomRes() {return AvStomRes;}
 double tCNode::getAvVegFraction() {return AvVegFraction;}
 double tCNode::getAvLeafAI() {return AvLeafAI;}
+// CJC2025: New Parameters
+double tCNode::getAvEvapThresh() {return AvEvapThresh;}
+double tCNode::getAvTransThresh() {return AvTransThresh;}
 
 int    tCNode::getFloodStatus()  { return flood; }
 int    tCNode::getSoilID()       { return soiID; }
@@ -795,6 +812,9 @@ void tCNode::setDrainExpPar(double value) {DrainExpPar = value; }
 void tCNode::setOptTransmCoeff(double value) { OptTransmCoeff = value; }
 void tCNode::setLeafAI(double value) { LeafAI = value; }
 void tCNode::setCanStorParam(double value) { CanStorParam = value; }
+// CJC2025: New Parameters
+void tCNode::setEvapThresh(double value) { EvapThresh = value; }
+void tCNode::setTransThresh(double value) { TransThresh = value; }
 
 // SKYnGM2008LU
 void tCNode::setLandUseAlbInPrevGrid(double value) { LandUseAlbInPrevGrid = value; }
@@ -821,6 +841,11 @@ void tCNode::setOptTransmCoeffInPrevGrid(double value) { OptTransmCoeffInPrevGri
 void tCNode::setOptTransmCoeffInUntilGrid(double value) { OptTransmCoeffInUntilGrid = value; }
 void tCNode::setLeafAIInPrevGrid(double value) { LeafAIInPrevGrid = value; }
 void tCNode::setLeafAIInUntilGrid(double value) { LeafAIInUntilGrid = value; }
+// CJC2025: New Parameters
+void tCNode::setEvapThreshInPrevGrid(double value) { EvapThreshInPrevGrid = value; }
+void tCNode::setEvapThreshInUntilGrid(double value) { EvapThreshInUntilGrid = value; }
+void tCNode::setTransThreshInPrevGrid(double value) { TransThreshInPrevGrid = value; }
+void tCNode::setTransThreshInUntilGrid(double value) { TransThreshInUntilGrid = value; }
 
 // SKYnGM2008LU
 void tCNode::setAvCanStorParam(double value) { AvCanStorParam = value; }
@@ -835,6 +860,9 @@ void tCNode::setAvOptTransmCoeff(double value) { AvOptTransmCoeff = value; }
 void tCNode::setAvStomRes(double value) { AvStomRes = value; }
 void tCNode::setAvVegFraction(double value) { AvVegFraction = value; }
 void tCNode::setAvLeafAI(double value) { AvLeafAI = value; }
+// CJC2025: New Parameters
+void tCNode::setAvEvapThresh(double value) { AvEvapThresh = value; }
+void tCNode::setAvTransThresh(double value) { AvTransThresh = value; }
 
 // Added by Giuseppe Mascaro in 2016 to allow ingestion of soil grids
 void tCNode::setKs(double value) { Ks = value;}
@@ -1339,6 +1367,9 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, OptTransmCoeff);
   BinaryWrite(rStr, LeafAI);
   BinaryWrite(rStr, CanStorParam);
+  // CJC2025: New Parameters
+  BinaryWrite(rStr, EvapThresh);
+  BinaryWrite(rStr, TransThresh);
 
   BinaryWrite(rStr, LandUseAlbInPrevGrid);
   BinaryWrite(rStr, LandUseAlbInUntilGrid);
@@ -1364,6 +1395,11 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, OptTransmCoeffInUntilGrid);
   BinaryWrite(rStr, LeafAIInPrevGrid);
   BinaryWrite(rStr, LeafAIInUntilGrid);
+  // CJC2025: New Parameters
+  BinaryWrite(rStr, EvapThreshInPrevGrid);
+  BinaryWrite(rStr, EvapThreshInUntilGrid);
+  BinaryWrite(rStr, TransThreshInPrevGrid);
+  BinaryWrite(rStr, TransThreshInUntilGrid);
 
   BinaryWrite(rStr, AvCanStorParam);
   BinaryWrite(rStr, AvIntercepCoeff);
@@ -1377,6 +1413,9 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, AvStomRes);
   BinaryWrite(rStr, AvVegFraction);
   BinaryWrite(rStr, AvLeafAI);
+  // CJC2025: New Parameters
+  BinaryWrite(rStr, AvEvapThresh);
+  BinaryWrite(rStr, AvTransThresh);
 
   BinaryWrite(rStr, cumHrsSun); // Snow
   BinaryWrite(rStr, cumLHF);
@@ -1607,6 +1646,9 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, OptTransmCoeff);
   BinaryRead(rStr, LeafAI);
   BinaryRead(rStr, CanStorParam);
+  // CJC2025: New Parameters
+  BinaryRead(rStr, EvapThresh);
+  BinaryRead(rStr, TransThresh);
 
   BinaryRead(rStr, LandUseAlbInPrevGrid);
   BinaryRead(rStr, LandUseAlbInUntilGrid);
@@ -1632,6 +1674,11 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, OptTransmCoeffInUntilGrid);
   BinaryRead(rStr, LeafAIInPrevGrid);
   BinaryRead(rStr, LeafAIInUntilGrid);
+  // CJC2025: New Parameters
+  BinaryRead(rStr, EvapThreshInPrevGrid);
+  BinaryRead(rStr, EvapThreshInUntilGrid);
+  BinaryRead(rStr, TransThreshInPrevGrid);
+  BinaryRead(rStr, TransThreshInUntilGrid);
 
   BinaryRead(rStr, AvCanStorParam);
   BinaryRead(rStr, AvIntercepCoeff);
@@ -1645,6 +1692,9 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, AvStomRes);
   BinaryRead(rStr, AvVegFraction);
   BinaryRead(rStr, AvLeafAI);
+  // CJC2025: New Parameters
+  BinaryRead(rStr, AvEvapThresh);
+  BinaryRead(rStr, AvTransThresh);
 
   BinaryRead(rStr, cumHrsSun); // Snow
   BinaryRead(rStr, cumLHF);
@@ -1847,6 +1897,9 @@ void tCNode::printVariables()
   cout << " OptTransmCoeff " << OptTransmCoeff;
   cout << " LeafAI " << LeafAI;
   cout << " CanStorParam " << CanStorParam;
+  // CJC2025: New Parameters
+  cout << " EvapThresh " << EvapThresh;
+  cout << " TransThresh " << TransThresh;
 
   cout << " LandUseAlbInPrevGrid " << LandUseAlbInPrevGrid;
   cout << " LandUseAlbInUntilGrid " << LandUseAlbInUntilGrid;
@@ -1872,6 +1925,11 @@ void tCNode::printVariables()
   cout << " OptTransmCoeffInUntilGrid " << OptTransmCoeffInUntilGrid;
   cout << " LeafAIInPrevGrid " << LeafAIInPrevGrid;
   cout << " LeafAIInUntilGrid " << LeafAIInUntilGrid;
+  // CJC2025: New Parameters
+  cout << " EvapThreshInPrevGrid " << EvapThreshInPrevGrid;
+  cout << " EvapThreshInUntilGrid " << EvapThreshInUntilGrid;
+  cout << " TransThreshInPrevGrid " << TransThreshInPrevGrid;
+  cout << " TransThreshInUntilGrid " << TransThreshInUntilGrid;
 
   cout << " AvCanStorParam " << AvCanStorParam;
   cout << " AvIntercepCoeff " << AvIntercepCoeff;
@@ -1885,6 +1943,9 @@ void tCNode::printVariables()
   cout << " AvStomRes " << AvStomRes;
   cout << " AvVegFraction " << AvVegFraction;
   cout << " AvLeafAI " << AvLeafAI;
+  // CJC2025: New Parameters
+  cout << " AvEvapThresh " << AvEvapThresh;
+  cout << " AvTransThresh " << AvTransThresh;
 
   cout << " cumHrsSun " << cumHrsSun; // Snow
   cout << " cumLHF " << cumLHF;

--- a/src/tCNode/tCNode.h
+++ b/src/tCNode/tCNode.h
@@ -277,6 +277,9 @@ public:
   double getOptTransmCoeff();
   double getLeafAI();
   double getCanStorParam();
+  // CJC2025: New Parameters
+  double getEvapThresh();
+  double getTransThresh();
 
   // SKYnGM2008LU
   double getLandUseAlbInPrevGrid();
@@ -303,6 +306,13 @@ public:
   double getOptTransmCoeffInUntilGrid();
   double getLeafAIInPrevGrid();
   double getLeafAIInUntilGrid();
+  // CJC2025: New Parameters
+  double getEvapThreshInPrevGrid();
+  double getEvapThreshInUntilGrid();
+  double getTransThreshInPrevGrid();
+  double getTransThreshInUntilGrid();
+
+
 
   // SKYnGM2008LU
   double getAvCanStorParam();
@@ -317,6 +327,9 @@ public:
   double getAvStomRes();
   double getAvVegFraction();
   double getAvLeafAI();
+  // CJC2025: New Parameters
+  double getAvEvapThresh();
+  double getAvTransThresh();
 
   double getAvSoilMoisture();         // Integral characteristics
   double getAvEvapFract();
@@ -465,6 +478,9 @@ public:
   void setOptTransmCoeff(double);
   void setLeafAI(double);
   void setCanStorParam(double);
+  // CJC2025: New Parameters
+  void setEvapThresh(double);
+  void setTransThresh(double);
 
   void setLandUseAlbInPrevGrid(double);
   void setLandUseAlbInUntilGrid(double);
@@ -490,6 +506,11 @@ public:
   void setOptTransmCoeffInUntilGrid(double);
   void setLeafAIInPrevGrid(double);
   void setLeafAIInUntilGrid(double);
+  // CJC2025: New Parameters
+  void setEvapThreshInPrevGrid(double);
+  void setEvapThreshInUntilGrid(double);
+  void setTransThreshInPrevGrid(double);
+  void setTransThreshInUntilGrid(double);
 
   // SKYnGM2008LU
   void setAvCanStorParam(double);
@@ -504,6 +525,9 @@ public:
   void setAvStomRes(double);
   void setAvVegFraction(double);
   void setAvLeafAI(double);
+  // CJC2025: New Parameters
+  void setAvEvapThresh(double);
+  void setAvTransThresh(double);
 
   void setAvSoilMoisture(double);     // Integral characteristics
   void setAvEvapFract(double);
@@ -800,6 +824,9 @@ protected:
   double OptTransmCoeff;
   double LeafAI;
   double CanStorParam;
+  // CJC2025: New Parameters
+  double EvapThresh;
+  double TransThresh;
 
   // SKYnGM2008LU
   double LandUseAlbInPrevGrid, LandUseAlbInUntilGrid, ThroughFallInPrevGrid, ThroughFallInUntilGrid;
@@ -808,11 +835,13 @@ protected:
   double IntercepCoeffInPrevGrid,IntercepCoeffInUntilGrid, CanFieldCapInPrevGrid, CanFieldCapInUntilGrid;
   double DrainCoeffInPrevGrid, DrainCoeffInUntilGrid, DrainExpParInPrevGrid, DrainExpParInUntilGrid;
   double OptTransmCoeffInPrevGrid, OptTransmCoeffInUntilGrid, LeafAIInPrevGrid, LeafAIInUntilGrid;
+  double EvapThreshInPrevGrid, EvapThreshInUntilGrid, TransThreshInPrevGrid, TransThreshInUntilGrid; // CJC2025: New Parameters
 
   // SKYnGM2008LU
   double AvCanStorParam, AvIntercepCoeff, AvThroughFall, AvCanFieldCap;
   double AvDrainCoeff, AvDrainExpPar, AvLandUseAlb, AvVegHeight;
   double AvOptTransmCoeff, AvStomRes, AvVegFraction, AvLeafAI;
+  double AvEvapThresh, AvTransThresh; // CJC2025: New Parameters
 
   double AvSoilMoisture;        // Integral characteristics
   double AvEvapFract;

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -217,20 +217,25 @@ class tEvapoTrans
   tVariant *CanStorParamGrid; 
   tVariant *IntercepCoeffGrid, *CanFieldCapGrid, *DrainCoeffGrid;
   tVariant *DrainExpParGrid, *OptTransmCoeffGrid, *LeafAIGrid;
+  tVariant *EvapThreshGrid, *TransThreshGrid; // CJC2025
 
   // SKYnGM2008LU
   int numALfiles{}, numTFfiles{}, numVHfiles{}, numSRfiles{};
   int numVFfiles{}, numCSfiles{}, numICfiles{}, numCCfiles{};
   int numDCfiles{}, numDEfiles{}, numOTfiles{}, numLAfiles{};
+  int numSEfiles{}, numSTfiles{}; // CJC2025 
   int *ALgridhours, *TFgridhours, *VHgridhours, *SRgridhours;
   int *VFgridhours, *CSgridhours, *ICgridhours, *CCgridhours;
   int *DCgridhours, *DEgridhours, *OTgridhours, *LAgridhours;  
+  int *SEgridhours, *STgridhours; // CJC2025
   int NowTillWhichALgrid{}, NowTillWhichTFgrid{}, NowTillWhichVHgrid{}, NowTillWhichSRgrid{};
   int NowTillWhichVFgrid{}, NowTillWhichCSgrid{}, NowTillWhichICgrid{}, NowTillWhichCCgrid{};
   int NowTillWhichDCgrid{}, NowTillWhichDEgrid{}, NowTillWhichOTgrid{}, NowTillWhichLAgrid{};
+  int NowTillWhichSEgrid{}, NowTillWhichSTgrid{}; // CJC2025
   char **ALgridFileNames, **TFgridFileNames, **VHgridFileNames, **SRgridFileNames;
   char **VFgridFileNames, **CSgridFileNames, **ICgridFileNames, **CCgridFileNames;
   char **DCgridFileNames, **DEgridFileNames, **OTgridFileNames, **LAgridFileNames;
+  char **SEgridFileNames, **STgridFileNames; // CJC2025
   int AtFirstTimeStepLUFlag{};
 
   int skycover_flag; // intended for when nodata is set for XC gridded data so that skycover is estimated.

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -183,6 +183,8 @@ class tEvapoTrans
   double Io{}, alphaD{}, sinAlpha{}, del{}, phi{}, tau{}, circ{}, sunaz{};
   double SunRisHrLoc{}, SunSetHrLoc{}, DayLength{}, deltaT{};
   double RadDirObs{}, RadDifObs{};
+  // CJC2025: New parameters
+  double coeffSE{}, coeffST{};
   // SKY2008Snow from AJR2007
   //new for sheltering algorithm
   //	RMK: THE HA* VARIABLES SHOULD ACTUALLY BE HANDLED IN AN ARRAY

--- a/src/tRasTin/tVariant.cpp
+++ b/src/tRasTin/tVariant.cpp
@@ -231,6 +231,15 @@ void tVariant::updateLUVarOfPrevGrid(const char *param, char *GridFileName)
 			cn->setLeafAIInPrevGrid( resample[id] );
 			cn->setLeafAI( resample[id] );
 		}
+		// CJC2025: New parameters
+		else if (strcmp(param,"SE") == 0) {
+			cn->setEvapThreshInPrevGrid( resample[id] );
+			cn->setEvapThresh( resample[id] );
+		}
+		else if (strcmp(param,"ST") == 0) {
+			cn->setTransThreshInPrevGrid( resample[id] );
+			cn->setTransThresh( resample[id] );
+		}
 
 		cn = nodeIter.NextP();
 		id++; 
@@ -322,6 +331,18 @@ void tVariant::updateLUVarOfBothGrids(const char *param, char *GridFileName)
 			cn->setLeafAI( cn->getLeafAIInUntilGrid() );
 			cn->setLeafAIInUntilGrid( resample[id] );
 		}
+		// CJC2025: New parameters
+		else if (strcmp(param,"SE") == 0) {
+			cn->setEvapThreshInPrevGrid( cn->getEvapThreshInUntilGrid() );
+			cn->setEvapThresh( cn->getEvapThreshInUntilGrid() );
+			cn->setEvapThreshInUntilGrid( resample[id] );
+		}
+		else if (strcmp(param,"ST") == 0) {
+			cn->setTransThreshInPrevGrid( cn->getTransThreshInUntilGrid() );
+			cn->setTransThresh( cn->getTransThreshInUntilGrid() );
+			cn->setTransThreshInUntilGrid( resample[id] );
+		}
+
 
 		cn = nodeIter.NextP();
 		id++; 


### PR DESCRIPTION
This PR introduces a new feature for reading gridded soil moisture stress thresholds and resolves a long-standing bug related to step-wise updates of dynamic land use parameters.

**New Feature: Gridded Stress Thresholds**

The model can now read gridded values for the soil moisture stress thresholds that control bare soil evaporation (`SE`) and plant transpiration (`ST`). This enhances the model's ability to represent spatial heterogeneity in plant and soil behavior.

This functionality has been added throughout the `tEvapoTrans` class, including:
- Reading grid names from the land use grid file (`.gdf`).
- Handling initialization, state management, and memory deallocation for the new `EvapThreshGrid` and `TransThreshGrid` variants.
- Applying the gridded values to `coeffSE` and `coeffST` during the simulation loop.

**Bug Fix: Step-wise Dynamic Land Use Updates**

Resolves a bug where using dynamic land use grids with the interpolation option turned off (`luInterpOption = 0`) could lead to incorrect model behavior or fatal solver errors.

*   **Problem:** When `luInterpOption` was set to `0`, the model would either silently use stale initial parameter values or crash with a `"Root must be bracketed..."` error from the soil physics solver. This forced users to always enable interpolation as a workaround.

*   **Root Cause:** The issue stemmed from two main problems:
    1.  **Faulty Initialization:** The `initialLUGridAssignment` function incorrectly used a state-advancing function (`updateLUVarOfBothGrids`) for initialization. This could copy uninitialized memory into the primary (`...InPrevGrid`) data slot, creating an invalid state.
    2.  **Missing State Application:** The main simulation loop was not re-applying the step-wise parameter values at each timestep.

*   **Solution:**
    1.  **Safe Initialization:** The logic in `initialLUGridAssignment` is now corrected to safely load the initial grid data using `updateLUVarOfPrevGrid` first, preventing the invalid memory copy.
    2.  **Consistent State Application:** The `callEvapoPotential` and `callEvapoTrans` functions now call the existing `constantLUGrids` function when `luInterpOption` is 0. This ensures the correct step-wise value is consistently applied.