### PR TITLE
fix: Prevent negative canopy storage from RK4 undershoot in Rutter Interception scheme

### DIFF
--- a/src/tHydro/tIntercept.cpp
+++ b/src/tHydro/tIntercept.cpp
@@ -319,6 +319,12 @@ void tIntercept::InterceptRutter(tCNode *cNode, double evaporation)
              // This can happen due to RK4 overshoot. If so, cap it.
              currentStorage = total_available_water;
         }
+
+		// The RK4 solver can undershoot and produce a non-physical negative storage.
+		// Correct this at the source before it propagates.
+		if (currentStorage < 0.0) {
+			currentStorage = 0.0;
+		}
 		
 		// Calculate the physically possible evaporation RATE
 		double avg_storage = (prevStorage + currentStorage) / 2.0;


### PR DESCRIPTION
This pull request resolves a bug causing negative values in the calculation of wet canopy evaporation (`EvpWetCan`).

The issue occurred during light rainfall on a dry canopy when evaporative demand was high. The root cause was the Runge-Kutta solver in `storageRungeKutta` calculating a small, non-physical negative canopy storage value. This negative value was then incorrectly added to the evaporation flux, resulting in a negative output.

The fix introduces a guardrail in `tIntercept::InterceptRutter` to clamp `currentStorage` to zero immediately after the RK4 calculation, ensuring all subsequent water balance operations use physically realistic values.