### PR TITLE
fix: Resolve crash in dynamic land use mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 cmake-build-debug*
 cmake-build-parallel
 cmake-build-serial
-build
+build*/
 _CPack_Packages
 __pycache__
 /cmake-build-serial_debug/

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -686,6 +686,7 @@ void tEvapoTrans::callEvapoPotential()
 	  }
 	  
 	  // Set Coefficients - override if dynamic land use
+	  setCoeffs(cNode);
 	  if (luOption == 1) {
 	    newLUGridData(cNode);
 	    if (gFluxOption == 1 || gFluxOption == 2) {
@@ -697,10 +698,6 @@ void tEvapoTrans::callEvapoPotential()
 			// Giuseppe 2016 - End changes to allow reading soil properties from grids
 	    }
 	  }
-	  else{
-	    setCoeffs(cNode);
-	  }
-
 
       //updates meteorological variables if not in stochastic mode
       if (!rainPtr->getoptStorm()) {
@@ -1048,16 +1045,14 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 
 	if ( evapotransOption ) {
 		
-		// Set Coefficients
+		// Set Coefficients - override if dynamic land use
+	    setCoeffs(cNode);
 		if (luOption == 1) {
 			newLUGridData(cNode);
 			if (gFluxOption == 1 || gFluxOption == 2) {;
                 coeffKs = cNode->getVolHeatCond();
                 coeffCs = cNode->getSoilHeatCap();
             }
-		}
-		else{
-		  setCoeffs(cNode);
 		}
 		
 		// Call Beta function for transpiration

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -440,6 +440,9 @@ void tHydroModel::InitSet(tResample *resamp)
 		Rs_LU   = landPtr->getLandProp(10);
 		V_LU    = landPtr->getLandProp(11);
 		LAI_LU  = landPtr->getLandProp(12);
+		// CJC2025 Stress Thresholds
+		SE_LU   = landPtr->getLandProp(13);
+		ST_LU   = landPtr->getLandProp(14);
 		cn->setLandUseAlb(Al_LU);
 		cn->setLandUseAlbInPrevGrid(Al_LU);
 		cn->setLandUseAlbInUntilGrid(Al_LU);
@@ -476,6 +479,13 @@ void tHydroModel::InitSet(tResample *resamp)
 		cn->setLeafAI(LAI_LU);
 		cn->setLeafAIInPrevGrid(LAI_LU);
 		cn->setLeafAIInUntilGrid(LAI_LU);
+		// CJC2025 Stress Thresholds
+		cn->setEvapThresh(SE_LU);
+		cn->setEvapThreshInPrevGrid(SE_LU);
+		cn->setEvapThreshInUntilGrid(SE_LU);
+		cn->setTransThresh(ST_LU);
+		cn->setTransThreshInPrevGrid(ST_LU);
+		cn->setTransThreshInUntilGrid(ST_LU);
 
 		// SKY2008Snow
 		cn->setLandFact(0.0);
@@ -572,6 +582,9 @@ void tHydroModel::InitIntegralVars()
 		Rs_LU   = landPtr->getLandProp(10);
 		V_LU    = landPtr->getLandProp(11);
 		LAI_LU  = landPtr->getLandProp(12);
+		// CJC2025 Stress Thresholds
+		SE_LU  = landPtr->getLandProp(13);
+		ST_LU  = landPtr->getLandProp(14);
 		cn->setAvCanStorParam(a_LU);
 		cn->setAvIntercepCoeff(b1_LU);
 		cn->setAvThroughFall(P_LU);
@@ -584,6 +597,8 @@ void tHydroModel::InitIntegralVars()
 		cn->setAvStomRes(Rs_LU);
 		cn->setAvVegFraction(V_LU);
 		cn->setAvLeafAI(LAI_LU);
+		cn->setAvEvapThresh(SE_LU);
+		cn->setAvTransThresh(ST_LU);
 
 		CheckMoistureContent( cn );
 	}
@@ -4464,6 +4479,8 @@ void tHydroModel::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, Rs_LU);
   BinaryWrite(rStr, V_LU);
   BinaryWrite(rStr, LAI_LU);
+  BinaryWrite(rStr, SE_LU);
+  BinaryWrite(rStr, ST_LU);
 
 }
 
@@ -4560,6 +4577,8 @@ void tHydroModel::readRestart(fstream & rStr)
   BinaryRead(rStr, Rs_LU);
   BinaryRead(rStr, V_LU);
   BinaryRead(rStr, LAI_LU);
+  BinaryRead(rStr, SE_LU);
+  BinaryRead(rStr, ST_LU);
 }
 
 //=========================================================================

--- a/src/tHydro/tHydroModel.h
+++ b/src/tHydro/tHydroModel.h
@@ -188,6 +188,9 @@ private:
   double Rs_LU{};
   double V_LU{};
   double LAI_LU{};
+  // CJC2025 Stress Thresholds
+  double ST_LU{};
+  double SE_LU{};
 
   // SKY2008Snow from AJR2007
   double snowMeltEx{};

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -1775,21 +1775,23 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
                << "AvOTCoeff" << ','    // 56
                << "AvStomRes" << ','    // 57
                << "AvVegFract" << ','    // 58
-               << "AvLeafAI"    // 59
-               << ',' << "Bedrock_Depth_mm"    // 60
-               << ',' << "Ks"    // 61
-               << ',' << "ThetaS"    // 62
-               << ',' << "ThetaR"    // 63
-               << ',' << "PoreSize"    // 64
-               << ',' << "AirEBubPress"    // 65
-               << ',' << "DecayF"    // 66
-               << ',' << "SatAnRatio"    // 67
-               << ',' << "UnsatAnRatio"    // 68
-               << ',' << "Porosity"    // 69
-               << ',' << "VolHeatCond"    // 70
-               << ',' << "SoilHeatCap"    // 71
-               << ',' << "SoilID"    // 72
-               << ',' << "LandUseID"    // 73
+               << "AvLeafAI" << ','    // 59
+               << "AvEvapThresh" << ','    // 60
+               << "AvTransThresh"    // 61
+               << ',' << "Bedrock_Depth_mm"    // 62
+               << ',' << "Ks"    // 63
+               << ',' << "ThetaS"    // 64
+               << ',' << "ThetaR"    // 65
+               << ',' << "PoreSize"    // 66
+               << ',' << "AirEBubPress"    // 67
+               << ',' << "DecayF"    // 67
+               << ',' << "SatAnRatio"    // 69
+               << ',' << "UnsatAnRatio"    // 70
+               << ',' << "Porosity"    // 71
+               << ',' << "VolHeatCond"    // 72
+               << ',' << "SoilHeatCap"    // 73
+               << ',' << "SoilID"    // 74
+               << ',' << "LandUseID"    // 75
                << "\n";
     }
 	
@@ -1912,20 +1914,22 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			<<setprecision(7)<<cn->getAvStomRes()<<',' // 57
 			<<setprecision(7)<<cn->getAvVegFraction()<<',' //58
 			<<setprecision(7)<<cn->getAvLeafAI()<<',' //59
-            <<setprecision(7)<<cn->getBedrockDepth()<<',' //60 bedrock depth mm
-           << setprecision(7) << cn->getKs() << ',' // 61
-           << setprecision(7) << cn->getThetaS() << ',' // 62
-           << setprecision(7) << cn->getThetaR() << ',' // 63
-           << setprecision(7) << cn->getPoreSize() << ',' // 64
-           << setprecision(7) << cn->getAirEBubPres() << ',' // 65
-           << setprecision(7) << cn->getDecayF() << ',' // 66
-           << setprecision(7) << cn->getSatAnRatio() << ',' // 67
-           << setprecision(7) << cn->getUnsatAnRatio() << ',' // 68
-           << setprecision(7) << cn->getPorosity() << ',' // 69
-           << setprecision(7) << cn->getVolHeatCond() << ',' // 70
-           << setprecision(7) << cn->getSoilHeatCap() << ',' // 71
-           << setprecision(7) << cn->getSoilID() << ',' //72
-           << setprecision(7) << cn->getLandUse(); // 73
+			<<setprecision(7)<<cn->getAvEvapThresh()<<',' //60
+			<<setprecision(7)<<cn->getAvTransThresh()<<',' //61
+            <<setprecision(7)<<cn->getBedrockDepth()<<',' //62 bedrock depth mm
+           << setprecision(7) << cn->getKs() << ',' // 63
+           << setprecision(7) << cn->getThetaS() << ',' // 64
+           << setprecision(7) << cn->getThetaR() << ',' // 65
+           << setprecision(7) << cn->getPoreSize() << ',' // 66
+           << setprecision(7) << cn->getAirEBubPres() << ',' // 67
+           << setprecision(7) << cn->getDecayF() << ',' // 68
+           << setprecision(7) << cn->getSatAnRatio() << ',' // 69
+           << setprecision(7) << cn->getUnsatAnRatio() << ',' // 70
+           << setprecision(7) << cn->getPorosity() << ',' // 71
+           << setprecision(7) << cn->getVolHeatCond() << ',' // 72
+           << setprecision(7) << cn->getSoilHeatCap() << ',' // 73
+           << setprecision(7) << cn->getSoilID() << ',' //74
+           << setprecision(7) << cn->getLandUse(); // 75
 
         intofs<<"\n";
 		


### PR DESCRIPTION
This hotfix addresses a bug that caused a crash when running in dynamic land use mode (`OPTLANDUSE = 1`) without providing grids for certain land use parameters. Additionally, the stress thresholds for soil and plant transpiration were added to the integrated spatial output file for user validation.

**The Bug:**
The previous logic skipped loading default parameter values from the land use table if `OPTLANDUSE = 1`. This left parameters values for the evaporation/transpiration stress thresholds uninitialized, leading to a crash.

**The Fix:**
The logic in `tEvapoTrans.cpp` has been updated to follow a "default, then override" pattern:
1.  Default parameters are now always loaded from the land use table at the start of the timestep.
2.  If `OPTLANDUSE = 1`, these defaults are then overwritten by any provided grid data.

This ensures that all parameters have a valid value for calculations, fully supporting hybrid land use configurations. This resolves the bug introduced in v5.3.0.