### PR TITLE
Add Support for Static Gridded Land Use Parameters

### DIFF
--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -654,7 +654,7 @@ void tEvapoTrans::callEvapoPotential()
 	  
 	  // Set Coefficients - override if dynamic land use
 	  setCoeffs(cNode);
-	  if (luOption == 1) {
+	  if (luOption == 1 || luOption == 2) {
 	    newLUGridData(cNode);
 	    if (gFluxOption == 1 || gFluxOption == 2) {
 			// Giuseppe 2016 - Begin changes to allow reading soil properties from grids
@@ -969,7 +969,7 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 		
 		// Set Coefficients - override if dynamic land use
 	    setCoeffs(cNode);
-		if (luOption == 1) {
+		if (luOption == 1 || luOption == 2) {
 			newLUGridData(cNode);
 			if (gFluxOption == 1 || gFluxOption == 2) {;
                 coeffKs = cNode->getVolHeatCond();
@@ -3816,17 +3816,6 @@ void tEvapoTrans::createStaticVariantLU()
         // Construct the full, non-timestamped filename
         snprintf(staticFileName, sizeof(staticFileName), "%s.%s", LUgridBaseNames[ct], LUgridExtNames[ct]);
 
-        // Check if the file actually exists before proceeding
-        ifstream fileCheck(staticFileName);
-        if (!fileCheck.good()) {
-            cerr << "\nFATAL ERROR: Static land use grid not found for parameter '"
-                 << LUgridParamNames[ct] << "'." << endl;
-            cerr << "Expected file at: " << staticFileName << endl;
-            cerr << "Exiting Program...\n\n" << endl;
-            exit(1);
-        }
-        fileCheck.close();
-
         cout << "\tReading static grid for " << LUgridParamNames[ct] << " from " << staticFileName << endl;
 
         // Use a switch statement for cleaner code
@@ -3883,7 +3872,7 @@ void tEvapoTrans::createStaticVariantLU()
     tMeshListIter<tCNode> nodeIter(gridPtr->getNodeList());
     cNode = nodeIter.FirstP();
     while (nodeIter.IsActive()) {
-        constantLUGrids(cNode);
+        constantLUGrids(cNode); // This copies data from "...InPrevGrid" to the active variable
         cNode = nodeIter.NextP();
     }
 }

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -291,7 +291,7 @@ void tEvapoTrans::CreateHydroMetAndLU(tInputFile &infile)
 		}
 
 		// Read observed data from files otherwise
-			if (luOption == 0) {
+		if (luOption == 0) {
 			Cout << "\nUsing ID Land-Use Map (OPTLANDUSE: 0)" << endl;
 		}
 		else if (luOption == 1) {

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -223,6 +223,10 @@ void tEvapoTrans::SetEvapTVariables(tInputFile &infile, tHydroModel *hydro)
 	if (luOption == 1) {
 		luInterpOption = infile.ReadItem(luInterpOption, "OPTLUINTERP"); // SKYnGM2008LU
 	}
+    // For static grids, interpolation is not applicable. CJC2025
+    else if (luOption == 2) {
+        luInterpOption = 0; // Default to constant values
+    }
 
 	snowOption = infile.ReadItem(snowOption, "OPTSNOW"); //read in snow options -- AJR 2007 @ NMT
 	shelterOption = infile.ReadItem(shelterOption, "OPTRADSHELT"); //read in shading option -- AJR 2007 @ NMT
@@ -287,17 +291,17 @@ void tEvapoTrans::CreateHydroMetAndLU(tInputFile &infile)
 		}
 
 		// Read observed data from files otherwise
-		if (luOption == 0) {
-			Cout << "\nUsing ID Land-Use Map" << endl;
+			if (luOption == 0) {
+			Cout << "\nUsing ID Land-Use Map (OPTLANDUSE: 0)" << endl;
 		}
 		else if (luOption == 1) {
-			cout << "\nUsing dynamic Land-Use Data Grids" << endl;
-			infile.ReadItem(luFile, "LUGRID"); // corrected by SY, TM: 11/19/07
+			cout << "\nUsing Dynamic (Time-Varying) Land-Use Data Grids (OPTLANDUSE: 1)" << endl;
+			infile.ReadItem(luFile, "LUGRID");
 			readLUGrid(luFile);
 			createVariantLU(); 
 			AtFirstTimeStepLUFlag=1;
 			if  ((luInterpOption != 0) && (luInterpOption != 1) ) {
-				Cout <<"\nLand Use Grid Interpolation Data Option "<< luOption <<" not valid."<<endl;
+				Cout <<"\nLand Use Grid Interpolation Data Option "<< luInterpOption <<" not valid."<<endl;
 				Cout << "\tPlease use :" << endl;
 				Cout << "\t\t(0) for using current/past values till next incoming grid" << endl;
 				Cout << "\t\t(1) for interpolating between curent/past and next incoming grids"<< endl;  
@@ -305,11 +309,20 @@ void tEvapoTrans::CreateHydroMetAndLU(tInputFile &infile)
 				exit(1);
 			}	
 		}
+        else if (luOption == 2) {
+            cout << "\nUsing Static (Spatially-Variable) Land-Use Data Grids (OPTLANDUSE: 2)" << endl;
+            infile.ReadItem(luFile, "LUGRID");
+            readLUGrid(luFile);
+            // We will call a new function to handle this simple case
+            createStaticVariantLU();
+            AtFirstTimeStepLUFlag = 0; // Not needed for this option
+        }
 		else {
 			Cout <<"\nLand Use Data Option "<< luOption<<" not valid."<<endl;
 			Cout << "\tPlease use :" << endl;
 			Cout << "\t\t(0) for ID Base Map" << endl;
-			Cout << "\t\t(1) for Gridded Land Use Data"<< endl;  
+			Cout << "\t\t(1) for Dynamic Gridded Land Use Data"<< endl;
+            Cout << "\t\t(2) for Static Gridded Land Use Data"<< endl;
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);
 		}
@@ -3784,6 +3797,95 @@ void tEvapoTrans::createVariantLU()
 			TransThreshGrid->newVariable(LUgridParamNames[ct]);
 		}
 	}
+}
+
+/***************************************************************************
+**
+** tEvapoTrans::createStaticVariantLU() Function
+**
+** Initializes tVariant objects for STATIC land use parameters.
+** Reads a single grid for each parameter and loads it once.
+** This function does not search for time-stamped files.
+**
+***************************************************************************/
+void tEvapoTrans::createStaticVariantLU()
+{
+    char staticFileName[kName];
+
+    for (int ct = 0; ct < nParmLU; ct++) {
+        // Construct the full, non-timestamped filename
+        snprintf(staticFileName, sizeof(staticFileName), "%s.%s", LUgridBaseNames[ct], LUgridExtNames[ct]);
+
+        // Check if the file actually exists before proceeding
+        ifstream fileCheck(staticFileName);
+        if (!fileCheck.good()) {
+            cerr << "\nFATAL ERROR: Static land use grid not found for parameter '"
+                 << LUgridParamNames[ct] << "'." << endl;
+            cerr << "Expected file at: " << staticFileName << endl;
+            cerr << "Exiting Program...\n\n" << endl;
+            exit(1);
+        }
+        fileCheck.close();
+
+        cout << "\tReading static grid for " << LUgridParamNames[ct] << " from " << staticFileName << endl;
+
+        // Use a switch statement for cleaner code
+        const std::string paramName = LUgridParamNames[ct];
+        
+        if (paramName == "AL") {
+            LandUseAlbGrid = new tVariant(gridPtr, respPtr);
+            LandUseAlbGrid->updateLUVarOfPrevGrid("AL", staticFileName);
+        } else if (paramName == "TF") {
+            ThroughFallGrid = new tVariant(gridPtr, respPtr);
+            ThroughFallGrid->updateLUVarOfPrevGrid("TF", staticFileName);
+        } else if (paramName == "VH") {
+            VegHeightGrid = new tVariant(gridPtr, respPtr);
+            VegHeightGrid->updateLUVarOfPrevGrid("VH", staticFileName);
+        } else if (paramName == "SR") {
+            StomResGrid = new tVariant(gridPtr, respPtr);
+            StomResGrid->updateLUVarOfPrevGrid("SR", staticFileName);
+        } else if (paramName == "VF") {
+            VegFractGrid = new tVariant(gridPtr, respPtr);
+            VegFractGrid->updateLUVarOfPrevGrid("VF", staticFileName);
+        } else if (paramName == "CS") {
+            CanStorParamGrid = new tVariant(gridPtr, respPtr);
+            CanStorParamGrid->updateLUVarOfPrevGrid("CS", staticFileName);
+        } else if (paramName == "IC") {
+            IntercepCoeffGrid = new tVariant(gridPtr, respPtr);
+            IntercepCoeffGrid->updateLUVarOfPrevGrid("IC", staticFileName);
+        } else if (paramName == "CC") {
+            CanFieldCapGrid = new tVariant(gridPtr, respPtr);
+            CanFieldCapGrid->updateLUVarOfPrevGrid("CC", staticFileName);
+        } else if (paramName == "DC") {
+            DrainCoeffGrid = new tVariant(gridPtr, respPtr);
+            DrainCoeffGrid->updateLUVarOfPrevGrid("DC", staticFileName);
+        } else if (paramName == "DE") {
+            DrainExpParGrid = new tVariant(gridPtr, respPtr);
+            DrainExpParGrid->updateLUVarOfPrevGrid("DE", staticFileName);
+        } else if (paramName == "OT") {
+            OptTransmCoeffGrid = new tVariant(gridPtr, respPtr);
+            OptTransmCoeffGrid->updateLUVarOfPrevGrid("OT", staticFileName);
+        } else if (paramName == "LA") {
+            LeafAIGrid = new tVariant(gridPtr, respPtr);
+            LeafAIGrid->updateLUVarOfPrevGrid("LA", staticFileName);
+        } else if (paramName == "SE") {
+            EvapThreshGrid = new tVariant(gridPtr, respPtr);
+            EvapThreshGrid->updateLUVarOfPrevGrid("SE", staticFileName);
+        } else if (paramName == "ST") {
+            TransThreshGrid = new tVariant(gridPtr, respPtr);
+            TransThreshGrid->updateLUVarOfPrevGrid("ST", staticFileName);
+        }
+    }
+
+    // After loading, we must immediately populate the node values from the 'PrevGrid'
+    // storage. This avoids running this logic in every time step.
+    tCNode* cNode;
+    tMeshListIter<tCNode> nodeIter(gridPtr->getNodeList());
+    cNode = nodeIter.FirstP();
+    while (nodeIter.IsActive()) {
+        constantLUGrids(cNode);
+        cNode = nodeIter.NextP();
+    }
 }
 
 /***************************************************************************

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -67,6 +67,7 @@ class tEvapoTrans
   void newLUGridData(tCNode *); // SKYnGM2008LU: added by AJR 2007
   void createVariant();
   void createVariantLU(); // SKYnGM2008LU: added by AJR 2007
+  void createStaticVariantLU(); // CJC2025
   void EvapPenmanMonteith(tCNode *);
   void EvapPan();
   void robustNess(double *, int);

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -602,7 +602,7 @@ void tHydroModel::InitIntegralVars()
 
 		CheckMoistureContent( cn );
 	}
-	}
+}
 
 /*************************************************************************
 **

--- a/src/tHydro/tIntercept.cpp
+++ b/src/tHydro/tIntercept.cpp
@@ -52,7 +52,7 @@ void tIntercept::SetIntercpVariables(tInputFile &inFile, tHydroModel *hydro)
 		landPtr = hydro->landPtr;  
 
 		// SKYnGM2008LU 
-		if (luOption == 1) {
+		if (luOption == 1 || luOption == 2) {
 			inFile.ReadItem(luFile, "LUGRID"); 
 			readLUGrid(luFile);
 		}
@@ -62,8 +62,11 @@ void tIntercept::SetIntercpVariables(tInputFile &inFile, tHydroModel *hydro)
 
 tIntercept::~tIntercept()
 {
-	if (luOption ==1) { 
-		DeleteIntercept();
+    // Only attempt to delete grid info if interception was active in the first place
+	if (interceptOption != 0) { 
+		if (luOption == 1 || luOption == 2) { 
+			DeleteIntercept();
+		}
 	}
 
 	Cout<<"tIntercept Object has been destroyed..."<<endl;

--- a/src/tHydro/tIntercept.cpp
+++ b/src/tHydro/tIntercept.cpp
@@ -488,7 +488,7 @@ void tIntercept::SetIntercpParameters(tCNode *cNode)
 		coeffV = landPtr->getLandProp(11);         //Vegetation Fraction 
 	}
 
-	if (luOption == 1) {
+	if (luOption == 1 || luOption == 2) {
 		for (int ct=0;ct<nParmLU;ct++) { 
 			if (strcmp(LUgridParamNames[ct],"CS")==0) {
 				if (interceptOption == 1) {

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -302,15 +302,6 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
         cNode->setVegFraction(landPtr->getLandProp(11));
         cNode->setLeafAI(landPtr->getLandProp(12));
 
-        if (luOption == 1) {
-            if (luInterpOption == 1) { // LU values linearly interpolated between 'previous' and 'until' values
-                interpolateLUGrids(cNode);
-            }
-            else if (luInterpOption == 0) {// LU values set from 'previous' grid
-                constantLUGrids(cNode);
-            }
-        }
-
         // Elapsed MET steps from the beginning, used for averaging dynamic LU grid values below over time for integ. output
         auto te = (double) timer->getElapsedMETSteps(timer->getCurrentTime());
         integratedLUVars(cNode, te);
@@ -327,10 +318,24 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
         snOnOff = 0.0;
 
         checkShelter(cNode);
-        setCoeffs(cNode);// this sets coeffs from land classification table
 
-        // this overwrites a given parameter if the landuse option is selected and the gridded data exists
-        if (luOption == 1) {
+        // Load the full set of default parameters from the table.
+        // This provides the fallback values for any parameters not supplied as grids.
+        setCoeffs(cNode);
+
+        // If using gridded data (dynamic or static), overwrite the defaults.
+        if (luOption == 1 || luOption == 2) {
+
+            // For DYNAMIC grids (Option 1), update/interpolate node values first.
+            if (luOption == 1) {
+                if (luInterpOption == 1) {
+                    interpolateLUGrids(cNode);
+                } else {
+                    constantLUGrids(cNode);
+                }
+            }
+            // For STATIC grids (Option 2), values are already on the node from initialization, so no action is needed here.
+            // For both gridded options, load the parameters from the node into the local 'coeff' variables.
             newLUGridData(cNode);
         }
 

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -288,7 +288,8 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
     while (nodeIter.IsActive()) {
         double precip = 0.0;
 
-        landPtr->setLandPtr(cNode->getLandUse());
+        // CJC2025 this block was overwriting land use parameters when it is not needed
+        /* landPtr->setLandPtr(cNode->getLandUse());
         cNode->setCanStorParam(landPtr->getLandProp(1));
         cNode->setIntercepCoeff(landPtr->getLandProp(2));
         cNode->setThroughFall(landPtr->getLandProp(3));
@@ -300,7 +301,7 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
         cNode->setOptTransmCoeff(landPtr->getLandProp(9));
         cNode->setStomRes(landPtr->getLandProp(10));
         cNode->setVegFraction(landPtr->getLandProp(11));
-        cNode->setLeafAI(landPtr->getLandProp(12));
+        cNode->setLeafAI(landPtr->getLandProp(12)); */
 
         // Elapsed MET steps from the beginning, used for averaging dynamic LU grid values below over time for integ. output
         auto te = (double) timer->getElapsedMETSteps(timer->getCurrentTime());


### PR DESCRIPTION
This pull request introduces a new feature that simplifies the use of spatially variable but temporally constant land use parameters. Previously, users wanting to provide a single parameter grid for an entire simulation had to use the dynamic grid option (`OPTLANDUSE = 1`) and add the simulation start date to the filename. This was inconvenient, as changing the simulation start date required renaming the parameter files.

This PR adds a new option, `OPTLANDUSE = 2`, which allows the model to read a single, non-time stamped static grid for each land use parameter. Simplifying the user experience.

#### Details

-   **New Input Option:** `OPTLANDUSE = 2`
-   **Functionality:** When this option is selected, the model reads the land use parameter grids specified in the gridded data file (.gdf) file like the previous tRIBS versions.
-   **File Naming:** The grid files should be named without a date stamp (e.g., `veg_fraction.asc` instead of `veg_fractionMMDDYYYYHH.asc`).
-   **Behavior:** The grid values are loaded once and held constant for the entire simulation. Parameters not provided as grids will still be read from the land use table.

#### Bug Fix

**Memory Leak in `tIntercept`:**
    -   **Problem:** The `tIntercept` destructor would try to deallocate memory for grid filenames even when interception was turned off (`OPTINTERCEPT = 0`), leading to a crash at the end of the simulation. This was because memory was only allocated when interception was on, but the destructor's check was incomplete. 
    -   **Fix:** Added a check for `interceptOption` in the `tIntercept` destructor to ensure that memory is only deallocated if it was allocated in the first place.
