### PR TITLE
Add gdal support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -g")
 # Release build-specific options, -O2 is the fastest
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
+option(WITH_GDAL "Build with GDAL support for GeoTIFF/NetCDF/etc." OFF)
+
 #set compiler if necessary, this has to be done before project()
 #set (CMAKE_CXX_COMPILER <specify compiler here>)
 #if(CMAKE_CXX_COMPILER_LOADED)
@@ -255,6 +257,33 @@ else()
             src/tSimulator/tSimul.h
     )
 
+endif()
+
+################################################################################
+# GDAL CONFIGURATION
+# This applies to both Serial and Parallel builds (target: ${exe})
+################################################################################
+if(WITH_GDAL)
+    find_package(GDAL)
+    
+    if(GDAL_FOUND)
+        message(STATUS "GDAL Found: ${GDAL_VERSION}")
+        message(STATUS "Enabling GDAL support.")
+
+        # 1. Define the preprocessor macro so the C++ code knows to compile the new function
+        target_compile_definitions(${exe} PRIVATE READ_GDAL)
+
+        # 2. Include header files
+        target_include_directories(${exe} PRIVATE ${GDAL_INCLUDE_DIRS})
+
+        # 3. Link the library
+        # We use PRIVATE because we don't want to expose GDAL to consumers of tRIBS
+        target_link_libraries(${exe} PRIVATE ${GDAL_LIBRARIES})
+
+    else()
+        message(WARNING "GDAL was requested (-DWITH_GDAL=ON) but not found on the system.")
+        message(WARNING "Compiling WITHOUT GDAL support (ASCII Grids only).")
+    endif()
 endif()
 
 # can be passed via the command line with -Dpackaging=ON

--- a/doc/md/CHANGELOG.md
+++ b/doc/md/CHANGELOG.md
@@ -2,12 +2,26 @@
 # Changelog 
 All notable changes to this project are documented in this file.
 
+## Version 6.0.0
+### 10/16/2025
+* Removed multiple legacy or unused options in the input file (stochastic storm generator, hydrometeorological converter, RIBS output compatibility, alternative visualization options).
+* The only available option for calculating ET from meteorological data is Penman-Monteith.
+* There are no longer multiple methods to provided gridded rainfall data. The user can provide either gridded or point station data, both in units of mm/hr.
+* The formats for providing a tin mesh to the model with `OPTMESHINPUT` have been simplified. Now there are only two options, a pre-generated mesh from the 4 mesh files or a point file.
+* Removed conditional header writing in model outputs. Headers are now always written.
+* Added new `OPTLANDUSE` option 2 for reading static landuse parameter rasters without needing dates in the filenames.
+* Added capability to read in raster data using GDAL. To activate the GDAL features the user must have GDAL installed already. When compiling tRIBS there is a new flag, `WITH_GDAL`, for turning on GDAL support. This feature allows tRIBS to read any raster type that GDAL is capable above but note that tRIBS does not support multi-band rasters. If a user does not enable `WITH_GDAL` while compiling the model will function the exact same as previous versions.
+## Version 5.3.1
+### 10/15/2025
+* Fixed bug in Rutter interception scheme that could result in small amount of negative wet canopy evaporation.
+* Added timestamp validation to meteorological station input timeseries.
+* Fixed bug when reading gridded landuse data that would result in the landuse table values being used instead under specific conditions.
 ## Version 5.3.0
 ### 8/16/2025
-* Remove extraneous cout statement that prints out `OptRES` during initialization.
+* Removed extraneous cout statement that prints out `OptRES` during initialization.
 * Removed hardcoded version number from the top of all source code files to conform to modern standards and simplify future model updates.
 * Replaced non-standard Variable Length Arrays (VLAs) with std::vector in tResample.cpp to resolve compiler warnings and improve code portability.
-* Improve numerical stability of raster resampling in tResample.cpp. This change fixes a bug with specific voronoi polygon geometry that would result in a NaN values for gridded parameters.
+* Improved numerical stability of raster resampling in tResample.cpp. This change fixes a bug with specific voronoi polygon geometry that would result in a NaN values for gridded parameters.
 ### 8/11/2025
 * Added new optional input for the gridded land use parameters. These parameters are the soil moisture stress thresholds for soil evaporation and plant transpiration, denoted by `SE` and `ST` in the gridded data file (.gdf), respectively.
 * Resolved a bug that could cause incorrect model behavior when using dynamic land use grids with the interpolation option turned off (`luInterpOption = 0`).

--- a/src/tRasTin/tResample.cpp
+++ b/src/tRasTin/tResample.cpp
@@ -15,6 +15,9 @@
 
 #include "src/tRasTin/tResample.h"
 #include "src/Headers/globalIO.h"
+#include <string>
+#include <algorithm>
+#include <cctype>
 
 //=========================================================================
 //
@@ -1054,6 +1057,114 @@ int* tResample::doIt(int *statID, double *XX, double *YY, int NN)
 	return varFromPoint;
 }
 
+#ifdef READ_GDAL
+/***************************************************************************
+**
+**  tResample::readInputGridGDAL(char *GridIn)
+**
+**  Reads raster data using the GDAL library.
+**  Populates gridIn, coorXG, coorYG, and extent variables.
+**
+***************************************************************************/
+void tResample::readInputGridGDAL(char *GridIn) 
+{
+    GDALAllRegister();
+
+    GDALDataset *poDataset = (GDALDataset *) GDALOpen(GridIn, GA_ReadOnly);
+    if( poDataset == NULL ) {
+        cout << "Error: GDAL could not open file " << GridIn << endl;
+        exit(2);
+    }
+
+    // 1. Get Dimensions
+    MR = poDataset->GetRasterXSize(); // Cols
+    NR = poDataset->GetRasterYSize(); // Rows
+
+    // 2. Get Geotransform (Positioning)
+    double adfGeoTransform[6];
+    if( poDataset->GetGeoTransform( adfGeoTransform ) == CE_None ) {
+        // [0] = Top-Left X
+        // [1] = W-E pixel resolution (Cell Size)
+        // [2] = 0
+        // [3] = Top-Left Y
+        // [4] = 0
+        // [5] = N-S pixel resolution (Negative value)
+        
+        xulcR = adfGeoTransform[0];
+        yulcR = adfGeoTransform[3];
+        dR = adfGeoTransform[1]; // Assuming square pixels
+        
+        // Calculate Lower Left (standard tRIBS internal) based on Top Left
+        // Note: adfGeoTransform[5] is usually negative.
+        xllcR = xulcR;
+        yllcR = yulcR + (NR * adfGeoTransform[5]); 
+    } else {
+        cout << "Warning: No GeoTransform found in " << GridIn << ". Assuming 0,0 origin." << endl;
+        xulcR = 0; yulcR = NR; xllcR = 0; yllcR = 0; dR = 1;
+    }
+
+    // 3. Get NoData Value
+    GDALRasterBand *poBand = poDataset->GetRasterBand(1);
+    int pbSuccess;
+    double noDataVal = poBand->GetNoDataValue(&pbSuccess);
+    if(pbSuccess) {
+        dummy = noDataVal;
+    } else {
+        dummy = -9999.0; // Default if not specified in file
+    }
+
+    // 4. Allocate Memory (Identical to original readInputGrid)
+    coorYG = new double [NR+1];
+    assert(coorYG != 0);
+    coorXG = new double [MR+1];
+    assert(coorXG != 0);
+
+    // Initialize Coordinate Arrays
+    double tempo = yulcR;
+    for (int i=0; i < NR+1; i++)  {
+        coorYG[i] = tempo;
+        tempo -= dR; // Moving down
+    }
+    double mott  = xulcR;
+    for (int j=0; j < MR+1; j++)  {
+        coorXG[j] = mott;
+        mott += dR; // Moving right
+    }
+
+    // 5. Allocate Grid Memory
+    gridIn = new double* [NR];
+    assert(gridIn != 0);
+
+    // 6. Read Data Row-by-Row
+    // We read directly into the row pointers to match tRIBS' expected memory layout.
+    for (int i=0; i < NR; i++) {
+        gridIn[i] = new double[MR];
+        assert(gridIn[i] != 0);
+
+        // GDAL RasterIO
+        // GF_Read, xOff, yOff, xSize, ySize, Buffer, BufXSize, BufYSize, Type, ...
+        CPLErr err = poBand->RasterIO(GF_Read, 
+                                      0, i,         // X offset 0, Y offset i (current row)
+                                      MR, 1,        // Read width MR, height 1
+                                      gridIn[i],    // Buffer: the current row pointer
+                                      MR, 1,        // Buffer dimensions
+                                      GDT_Float64,  // Read as Double
+                                      0, 0);
+        
+        if (err != CE_None) {
+            cout << "Error reading raster row " << i << endl;
+            exit(2);
+        }
+    }
+
+    GDALClose( (GDALDatasetH) poDataset );
+    
+    if (simCtrl->Verbose_label == 'Y') {
+        cout << "\tGDAL Load Complete: " << MR << "x" << NR << " CellSize: " << dR << endl;
+    }
+}
+#endif
+
 /***************************************************************************
 **
 **  tResample::readInputGrid(char *GridIn)
@@ -1065,6 +1176,39 @@ int* tResample::doIt(int *statID, double *XX, double *YY, int NN)
 ***************************************************************************/
 void tResample::readInputGrid(char *GridIn) 
 {
+    // --- STEP 1: DETECT FORMAT ---
+    bool isLegacyAscii = false;
+
+    // Open file just to peek at the first token
+    ifstream peekFile(GridIn);
+    if (!peekFile) {
+        // Let the legacy code handle the "File not found" error nicely below
+        // or handle it here if you prefer.
+    } else {
+        std::string firstToken;
+        peekFile >> firstToken; // Read first string (skips whitespace)
+        peekFile.close();
+
+        // Convert to uppercase for comparison
+        std::transform(firstToken.begin(), firstToken.end(), firstToken.begin(), 
+                       [](unsigned char c){ return std::toupper(c); });
+
+        // ArcInfo ASCII Grids must start with NCOLS (or rarely COLS)
+        if (firstToken == "NCOLS" || firstToken == "COLS") {
+            isLegacyAscii = true;
+        }
+    }
+
+	#ifdef READ_GDAL
+		// --- STEP 2: ROUTE TO GDAL IF NOT ASCII ---
+		if (!isLegacyAscii) {
+			// If it doesn't look like ASCII, we assume it's a format GDAL handles.
+			// If it's actually just a broken file, GDAL will throw the error.
+			readInputGridGDAL(GridIn);
+			return; 
+		}
+	#endif
+
 	int i,j;
 	double tempo, mott;
 	char lineIn[300];

--- a/src/tRasTin/tResample.h
+++ b/src/tRasTin/tResample.h
@@ -15,6 +15,11 @@
 
 #ifndef  TRESAMPLE_H
 #define  TRESAMPLE_H
+// Add GDAL support CJC2025
+#ifdef READ_GDAL
+#include "gdal_priv.h"
+#include "cpl_conv.h"
+#endif
 
 #include "src/Headers/Inclusions.h"
 
@@ -72,6 +77,10 @@ class tResample
   void    PrintEdgeInfo(tEdge *); 
 
   void    readInputGrid(char *);
+  #ifdef READ_GDAL
+    // The GDAL specific reader CJC2025
+    void readInputGridGDAL(char *GridIn);
+  #endif
   void    DestrtResample();
   void    allocMemory(double **, int, int);
   void    In_Mrain_Name (char *, char *, int, int, int, int);


### PR DESCRIPTION
Added an optional build configuration to link against GDAL, allowing tRIBS to read binary raster formats.

Key changes:
1. Modified `tResample.cpp` to inspect file headers. Files starting with "NCOLS" continue to use the legacy ASCII parser.
2. All other file streams are routed to the new GDAL reader, preserving coordinate system translation (Top-Left to Bottom-Left).
3. Added `WITH_GDAL` flag to CMake to prevent breaking builds on systems without GDAL.

Validation:
Tested with GeoTIFF inputs against baseline ASCII data; spatial results match exactly.