### PR TITLE
refactor: Remove Gray Interception Scheme

### DIFF
--- a/src/tCNode/tCNode.cpp
+++ b/src/tCNode/tCNode.cpp
@@ -93,22 +93,21 @@ tCNode::tCNode() :tNode()
 	LandUseAlb = ThroughFall = VegHeight = StomRes = 0.0; 
 
 	// SKYnGM2008LU
-	IntercepCoeff = CanFieldCap = DrainCoeff = 0.0;  
-	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;	
-	CanStorParam = 0.0;
+	CanFieldCap = DrainCoeff = 0.0;
+	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;
   EvapThresh = TransThresh = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
 	VegHeightInPrevGrid = VegHeightInUntilGrid = StomResInPrevGrid = StomResInUntilGrid = 0.0;
-	VegFractionInPrevGrid = VegFractionInUntilGrid = CanStorParamInPrevGrid = CanStorParamInUntilGrid = 0.0;
-	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
+	VegFractionInPrevGrid = VegFractionInUntilGrid = 0.0;
+	CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
   EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
 
 	// SKYnGM2008LU
-	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
+	AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
   AvEvapThresh = AvTransThresh = 0.0; // CJC2025
@@ -228,22 +227,21 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	LandUseAlb = ThroughFall = VegHeight = StomRes = 0.0; 
 
 	// SKYnGM2008LU
-	IntercepCoeff = CanFieldCap = DrainCoeff = 0.0; 
+	CanFieldCap = DrainCoeff = 0.0;
 	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;
-        CanStorParam = 0.0;	
   EvapThresh = TransThresh = 0.0; // CJC2025
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
 	VegHeightInPrevGrid = VegHeightInUntilGrid = StomResInPrevGrid = StomResInUntilGrid = 0.0;
-	VegFractionInPrevGrid = VegFractionInUntilGrid = CanStorParamInPrevGrid = CanStorParamInUntilGrid = 0.0;
-	IntercepCoeffInPrevGrid = IntercepCoeffInUntilGrid = CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
+	VegFractionInPrevGrid = VegFractionInUntilGrid = 0.0;
+	CanFieldCapInPrevGrid = CanFieldCapInUntilGrid = 0.0;
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
   EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
 
 	// SKYnGM2008LU
-	AvCanStorParam = AvIntercepCoeff = AvThroughFall = AvCanFieldCap = 0.0;
+	AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
   AvEvapThresh = AvTransThresh = 0.0; // CJC2025
@@ -457,13 +455,11 @@ double tCNode::getVegHeight() {return VegHeight;}
 double tCNode::getStomRes() {return StomRes;}
 
 // SKYnGM2008LU
-double tCNode::getIntercepCoeff() {return IntercepCoeff;}
 double tCNode::getCanFieldCap() {return CanFieldCap;}
 double tCNode::getDrainCoeff() {return DrainCoeff;}
 double tCNode::getDrainExpPar() {return DrainExpPar;}
 double tCNode::getOptTransmCoeff() {return OptTransmCoeff;}
 double tCNode::getLeafAI() {return LeafAI;}
-double tCNode::getCanStorParam() {return CanStorParam;}
 // CJC2025: New Parameters
 double tCNode::getEvapThresh() {return EvapThresh;}
 double tCNode::getTransThresh() {return TransThresh;}
@@ -479,10 +475,6 @@ double tCNode::getStomResInPrevGrid() {return StomResInPrevGrid;}
 double tCNode::getStomResInUntilGrid() {return StomResInUntilGrid;}
 double tCNode::getVegFractionInPrevGrid() {return VegFractionInPrevGrid;}
 double tCNode::getVegFractionInUntilGrid() {return VegFractionInUntilGrid;}
-double tCNode::getCanStorParamInPrevGrid() {return CanStorParamInPrevGrid;}
-double tCNode::getCanStorParamInUntilGrid() {return CanStorParamInUntilGrid;}
-double tCNode::getIntercepCoeffInPrevGrid() {return IntercepCoeffInPrevGrid;}
-double tCNode::getIntercepCoeffInUntilGrid() {return IntercepCoeffInUntilGrid;}
 double tCNode::getCanFieldCapInPrevGrid() {return CanFieldCapInPrevGrid;}
 double tCNode::getCanFieldCapInUntilGrid() {return CanFieldCapInUntilGrid;}
 double tCNode::getDrainCoeffInPrevGrid() {return DrainCoeffInPrevGrid;}
@@ -500,8 +492,6 @@ double tCNode::getTransThreshInPrevGrid() {return TransThreshInPrevGrid;}
 double tCNode::getTransThreshInUntilGrid() {return TransThreshInUntilGrid;} 
 
 // SKYnGM2008LU
-double tCNode::getAvCanStorParam() {return AvCanStorParam;}
-double tCNode::getAvIntercepCoeff() {return AvIntercepCoeff;}
 double tCNode::getAvThroughFall() {return AvThroughFall;}
 double tCNode::getAvCanFieldCap() {return AvCanFieldCap;}
 double tCNode::getAvDrainCoeff() {return AvDrainCoeff;}
@@ -806,13 +796,11 @@ void tCNode::setVegHeight(double value) { VegHeight = value; }
 void tCNode::setStomRes(double value) {StomRes = value; }
 
 // SKYnGM2008LU
-void tCNode::setIntercepCoeff(double value) { IntercepCoeff = value; }
 void tCNode::setCanFieldCap(double value) { CanFieldCap = value; }
 void tCNode::setDrainCoeff(double value) { DrainCoeff = value; }
 void tCNode::setDrainExpPar(double value) {DrainExpPar = value; }
 void tCNode::setOptTransmCoeff(double value) { OptTransmCoeff = value; }
 void tCNode::setLeafAI(double value) { LeafAI = value; }
-void tCNode::setCanStorParam(double value) { CanStorParam = value; }
 // CJC2025: New Parameters
 void tCNode::setEvapThresh(double value) { EvapThresh = value; }
 void tCNode::setTransThresh(double value) { TransThresh = value; }
@@ -828,10 +816,6 @@ void tCNode::setStomResInPrevGrid(double value) { StomResInPrevGrid = value; }
 void tCNode::setStomResInUntilGrid(double value) { StomResInUntilGrid = value; }
 void tCNode::setVegFractionInPrevGrid(double value) { VegFractionInPrevGrid = value; }
 void tCNode::setVegFractionInUntilGrid(double value) { VegFractionInUntilGrid = value; }
-void tCNode::setCanStorParamInPrevGrid(double value) { CanStorParamInPrevGrid = value; }
-void tCNode::setCanStorParamInUntilGrid(double value) { CanStorParamInUntilGrid = value; }
-void tCNode::setIntercepCoeffInPrevGrid(double value) { IntercepCoeffInPrevGrid = value; }
-void tCNode::setIntercepCoeffInUntilGrid(double value) { IntercepCoeffInUntilGrid = value; }
 void tCNode::setCanFieldCapInPrevGrid(double value) { CanFieldCapInPrevGrid = value; }
 void tCNode::setCanFieldCapInUntilGrid(double value) { CanFieldCapInUntilGrid = value; }
 void tCNode::setDrainCoeffInPrevGrid(double value) { DrainCoeffInPrevGrid = value; }
@@ -849,8 +833,6 @@ void tCNode::setTransThreshInPrevGrid(double value) { TransThreshInPrevGrid = va
 void tCNode::setTransThreshInUntilGrid(double value) { TransThreshInUntilGrid = value; }
 
 // SKYnGM2008LU
-void tCNode::setAvCanStorParam(double value) { AvCanStorParam = value; }
-void tCNode::setAvIntercepCoeff(double value) { AvIntercepCoeff = value; }
 void tCNode::setAvThroughFall(double value) { AvThroughFall = value; }
 void tCNode::setAvCanFieldCap(double value) { AvCanFieldCap = value; }
 void tCNode::setAvDrainCoeff(double value) { AvDrainCoeff = value; }
@@ -1362,13 +1344,11 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, ThroughFall);
   BinaryWrite(rStr, VegHeight);
   BinaryWrite(rStr, StomRes);
-  BinaryWrite(rStr, IntercepCoeff);
   BinaryWrite(rStr, CanFieldCap);
   BinaryWrite(rStr, DrainCoeff);
   BinaryWrite(rStr, DrainExpPar);
   BinaryWrite(rStr, OptTransmCoeff);
   BinaryWrite(rStr, LeafAI);
-  BinaryWrite(rStr, CanStorParam);
   // CJC2025: New Parameters
   BinaryWrite(rStr, EvapThresh);
   BinaryWrite(rStr, TransThresh);
@@ -1383,10 +1363,6 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, StomResInUntilGrid);
   BinaryWrite(rStr, VegFractionInPrevGrid);
   BinaryWrite(rStr, VegFractionInUntilGrid);
-  BinaryWrite(rStr, CanStorParamInPrevGrid);
-  BinaryWrite(rStr, CanStorParamInUntilGrid);
-  BinaryWrite(rStr, IntercepCoeffInPrevGrid);
-  BinaryWrite(rStr, IntercepCoeffInUntilGrid);
   BinaryWrite(rStr, CanFieldCapInPrevGrid);
   BinaryWrite(rStr, CanFieldCapInUntilGrid);
   BinaryWrite(rStr, DrainCoeffInPrevGrid);
@@ -1403,8 +1379,6 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, TransThreshInPrevGrid);
   BinaryWrite(rStr, TransThreshInUntilGrid);
 
-  BinaryWrite(rStr, AvCanStorParam);
-  BinaryWrite(rStr, AvIntercepCoeff);
   BinaryWrite(rStr, AvThroughFall);
   BinaryWrite(rStr, AvCanFieldCap);
   BinaryWrite(rStr, AvDrainCoeff);
@@ -1642,13 +1616,11 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, ThroughFall);
   BinaryRead(rStr, VegHeight);
   BinaryRead(rStr, StomRes);
-  BinaryRead(rStr, IntercepCoeff);
   BinaryRead(rStr, CanFieldCap);
   BinaryRead(rStr, DrainCoeff);
   BinaryRead(rStr, DrainExpPar);
   BinaryRead(rStr, OptTransmCoeff);
   BinaryRead(rStr, LeafAI);
-  BinaryRead(rStr, CanStorParam);
   // CJC2025: New Parameters
   BinaryRead(rStr, EvapThresh);
   BinaryRead(rStr, TransThresh);
@@ -1663,10 +1635,6 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, StomResInUntilGrid);
   BinaryRead(rStr, VegFractionInPrevGrid);
   BinaryRead(rStr, VegFractionInUntilGrid);
-  BinaryRead(rStr, CanStorParamInPrevGrid);
-  BinaryRead(rStr, CanStorParamInUntilGrid);
-  BinaryRead(rStr, IntercepCoeffInPrevGrid);
-  BinaryRead(rStr, IntercepCoeffInUntilGrid);
   BinaryRead(rStr, CanFieldCapInPrevGrid);
   BinaryRead(rStr, CanFieldCapInUntilGrid);
   BinaryRead(rStr, DrainCoeffInPrevGrid);
@@ -1683,8 +1651,6 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, TransThreshInPrevGrid);
   BinaryRead(rStr, TransThreshInUntilGrid);
 
-  BinaryRead(rStr, AvCanStorParam);
-  BinaryRead(rStr, AvIntercepCoeff);
   BinaryRead(rStr, AvThroughFall);
   BinaryRead(rStr, AvCanFieldCap);
   BinaryRead(rStr, AvDrainCoeff);
@@ -1894,13 +1860,11 @@ void tCNode::printVariables()
   cout << " ThroughFall " << ThroughFall;
   cout << " VegHeight " << VegHeight;
   cout << " StomRes " << StomRes;
-  cout << " IntercepCoeff " << IntercepCoeff;
   cout << " CanFieldCap " << CanFieldCap;
   cout << " DrainCoeff " << DrainCoeff;
   cout << " DrainExpPar " << DrainExpPar;
   cout << " OptTransmCoeff " << OptTransmCoeff;
   cout << " LeafAI " << LeafAI;
-  cout << " CanStorParam " << CanStorParam;
   // CJC2025: New Parameters
   cout << " EvapThresh " << EvapThresh;
   cout << " TransThresh " << TransThresh;
@@ -1915,10 +1879,6 @@ void tCNode::printVariables()
   cout << " StomResInUntilGrid " << StomResInUntilGrid;
   cout << " VegFractionInPrevGrid " << VegFractionInPrevGrid;
   cout << " VegFractionInUntilGrid " << VegFractionInUntilGrid;
-  cout << " CanStorParamInPrevGrid " << CanStorParamInPrevGrid;
-  cout << " CanStorParamInUntilGrid " << CanStorParamInUntilGrid;
-  cout << " IntercepCoeffInPrevGrid " << IntercepCoeffInPrevGrid;
-  cout << " IntercepCoeffInUntilGrid " << IntercepCoeffInUntilGrid;
   cout << " CanFieldCapInPrevGrid " << CanFieldCapInPrevGrid;
   cout << " CanFieldCapInUntilGrid " << CanFieldCapInUntilGrid;
   cout << " DrainCoeffInPrevGrid " << DrainCoeffInPrevGrid;
@@ -1935,8 +1895,6 @@ void tCNode::printVariables()
   cout << " TransThreshInPrevGrid " << TransThreshInPrevGrid;
   cout << " TransThreshInUntilGrid " << TransThreshInUntilGrid;
 
-  cout << " AvCanStorParam " << AvCanStorParam;
-  cout << " AvIntercepCoeff " << AvIntercepCoeff;
   cout << " AvThroughFall " << AvThroughFall;
   cout << " AvCanFieldCap " << AvCanFieldCap;
   cout << " AvDrainCoeff " << AvDrainCoeff;

--- a/src/tCNode/tCNode.h
+++ b/src/tCNode/tCNode.h
@@ -246,13 +246,11 @@ public:
   double getStomRes();
 
   // SKYnGM2008LU
-  double getIntercepCoeff();
   double getCanFieldCap();
   double getDrainCoeff();
   double getDrainExpPar();
   double getOptTransmCoeff();
   double getLeafAI();
-  double getCanStorParam();
   // CJC2025: New Parameters
   double getEvapThresh();
   double getTransThresh();
@@ -268,10 +266,6 @@ public:
   double getStomResInUntilGrid();
   double getVegFractionInPrevGrid();
   double getVegFractionInUntilGrid();
-  double getCanStorParamInPrevGrid();
-  double getCanStorParamInUntilGrid();
-  double getIntercepCoeffInPrevGrid();
-  double getIntercepCoeffInUntilGrid();
   double getCanFieldCapInPrevGrid();
   double getCanFieldCapInUntilGrid();
   double getDrainCoeffInPrevGrid();
@@ -291,8 +285,6 @@ public:
 
 
   // SKYnGM2008LU
-  double getAvCanStorParam();
-  double getAvIntercepCoeff();
   double getAvThroughFall();
   double getAvCanFieldCap();
   double getAvDrainCoeff();
@@ -448,13 +440,11 @@ public:
   void setStomRes(double);
 
   // SKYnGM2008LU
-  void setIntercepCoeff(double);
   void setCanFieldCap(double);
   void setDrainCoeff(double);
   void setDrainExpPar(double);
   void setOptTransmCoeff(double);
   void setLeafAI(double);
-  void setCanStorParam(double);
   // CJC2025: New Parameters
   void setEvapThresh(double);
   void setTransThresh(double);
@@ -469,10 +459,6 @@ public:
   void setStomResInUntilGrid(double);
   void setVegFractionInPrevGrid(double);
   void setVegFractionInUntilGrid(double);
-  void setCanStorParamInPrevGrid(double);
-  void setCanStorParamInUntilGrid(double);
-  void setIntercepCoeffInPrevGrid(double);
-  void setIntercepCoeffInUntilGrid(double);
   void setCanFieldCapInPrevGrid(double);
   void setCanFieldCapInUntilGrid(double);
   void setDrainCoeffInPrevGrid(double);
@@ -490,8 +476,6 @@ public:
   void setTransThreshInUntilGrid(double);
 
   // SKYnGM2008LU
-  void setAvCanStorParam(double);
-  void setAvIntercepCoeff(double);
   void setAvThroughFall(double);
   void setAvCanFieldCap(double);
   void setAvDrainCoeff(double);
@@ -796,13 +780,11 @@ protected:
   double StomRes;
 
   // SKYnGM2008LU
-  double IntercepCoeff;
   double CanFieldCap;
   double DrainCoeff;
   double DrainExpPar;
   double OptTransmCoeff;
   double LeafAI;
-  double CanStorParam;
   // CJC2025: New Parameters
   double EvapThresh;
   double TransThresh;
@@ -810,14 +792,14 @@ protected:
   // SKYnGM2008LU
   double LandUseAlbInPrevGrid, LandUseAlbInUntilGrid, ThroughFallInPrevGrid, ThroughFallInUntilGrid;
   double VegHeightInPrevGrid, VegHeightInUntilGrid, StomResInPrevGrid, StomResInUntilGrid;
-  double VegFractionInPrevGrid, VegFractionInUntilGrid, CanStorParamInPrevGrid, CanStorParamInUntilGrid;
-  double IntercepCoeffInPrevGrid,IntercepCoeffInUntilGrid, CanFieldCapInPrevGrid, CanFieldCapInUntilGrid;
+  double VegFractionInPrevGrid, VegFractionInUntilGrid;
+  double CanFieldCapInPrevGrid, CanFieldCapInUntilGrid;
   double DrainCoeffInPrevGrid, DrainCoeffInUntilGrid, DrainExpParInPrevGrid, DrainExpParInUntilGrid;
   double OptTransmCoeffInPrevGrid, OptTransmCoeffInUntilGrid, LeafAIInPrevGrid, LeafAIInUntilGrid;
   double EvapThreshInPrevGrid, EvapThreshInUntilGrid, TransThreshInPrevGrid, TransThreshInUntilGrid; // CJC2025: New Parameters
 
   // SKYnGM2008LU
-  double AvCanStorParam, AvIntercepCoeff, AvThroughFall, AvCanFieldCap;
+  double AvThroughFall, AvCanFieldCap;
   double AvDrainCoeff, AvDrainExpPar, AvLandUseAlb, AvVegHeight;
   double AvOptTransmCoeff, AvStomRes, AvVegFraction, AvLeafAI;
   double AvEvapThresh, AvTransThresh; // CJC2025: New Parameters

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -68,8 +68,6 @@ tEvapoTrans::tEvapoTrans()
 	VegHeightGrid = nullptr;
 	StomResGrid = nullptr;
 	VegFractGrid = nullptr;
-	CanStorParamGrid = nullptr;
-	IntercepCoeffGrid = nullptr;
 	CanFieldCapGrid = nullptr;
 	DrainCoeffGrid = nullptr;
 	DrainExpParGrid = nullptr;
@@ -82,8 +80,6 @@ tEvapoTrans::tEvapoTrans()
 	VHgridhours = nullptr;
 	SRgridhours = nullptr;
 	VFgridhours = nullptr;
-	CSgridhours = nullptr;
-	ICgridhours = nullptr;
 	CCgridhours = nullptr;
 	DCgridhours = nullptr;
 	DEgridhours = nullptr;
@@ -96,8 +92,6 @@ tEvapoTrans::tEvapoTrans()
 	VHgridFileNames = nullptr;
 	SRgridFileNames = nullptr;
 	VFgridFileNames = nullptr;
-	CSgridFileNames = nullptr;
-	ICgridFileNames = nullptr;
 	CCgridFileNames = nullptr;
 	DCgridFileNames = nullptr;
 	DEgridFileNames = nullptr;
@@ -147,8 +141,6 @@ tEvapoTrans::tEvapoTrans(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 	VegHeightGrid = nullptr;
 	StomResGrid = nullptr;
 	VegFractGrid = nullptr;
-	CanStorParamGrid = nullptr;
-	IntercepCoeffGrid = nullptr;
 	CanFieldCapGrid = nullptr;
 	DrainCoeffGrid = nullptr;
 	DrainExpParGrid = nullptr;
@@ -161,8 +153,6 @@ tEvapoTrans::tEvapoTrans(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 	VHgridhours = nullptr;
 	SRgridhours = nullptr;
 	VFgridhours = nullptr;
-	CSgridhours = nullptr;
-	ICgridhours = nullptr;
 	CCgridhours = nullptr;
 	DCgridhours = nullptr;
 	DEgridhours = nullptr;
@@ -175,8 +165,6 @@ tEvapoTrans::tEvapoTrans(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 	VHgridFileNames = nullptr;
 	SRgridFileNames = nullptr;
 	VFgridFileNames = nullptr;
-	CSgridFileNames = nullptr;
-	ICgridFileNames = nullptr;
 	CCgridFileNames = nullptr;
 	DCgridFileNames = nullptr;
 	DEgridFileNames = nullptr;
@@ -841,21 +829,21 @@ void tEvapoTrans::setCoeffs(tCNode* cNode)
 	landPtr->setLandPtr(cNode->getLandUse());
 
 	if (snowOption == 1)
-		coeffLAI = landPtr->getLandProp(12);
+		coeffLAI = landPtr->getLandProp(10);
 
 	if (evapotransOption == 1) {
-		coeffAl = landPtr->getLandProp(7); 
-		coeffH  = landPtr->getLandProp(8); 
-		coeffKt = landPtr->getLandProp(9);
-		coeffRs = landPtr->getLandProp(10);
-		coeffV  = landPtr->getLandProp(11);
+		coeffAl = landPtr->getLandProp(5);
+		coeffH  = landPtr->getLandProp(6);
+		coeffKt = landPtr->getLandProp(7);
+		coeffRs = landPtr->getLandProp(8);
+		coeffV  = landPtr->getLandProp(9);
 	}
 	else if (evapotransOption == 2)
-		coeffV  = landPtr->getLandProp(11);
-		
+		coeffV  = landPtr->getLandProp(9);
+
 	// CJC2025: Set the values for the stress thresholds from the table.
-    coeffSE = landPtr->getLandProp(13);
-    coeffST = landPtr->getLandProp(14);
+    coeffSE = landPtr->getLandProp(11);
+    coeffST = landPtr->getLandProp(12);
 
     if (coeffV >= 1.0) //prevents loss of snow when unloaded from canopy WR 05/12/2024
         coeffV = 0.99;
@@ -909,7 +897,7 @@ void tEvapoTrans::callEvapoTrans(tIntercept *Intercept, int flag)
 	}
 
 	// SKYnGM2008LU: Following handles the 'Interception ON' case in SurfaceHydroProcesses
-	if (getEToption() == 0 && Intercept->getIoption() == 1) {
+	if (getEToption() == 0 && Intercept->getIoption() != 0) {
 	  if (luOption == 1) { // resampling Land Use grids done here, i.e., dynamic case
 	    if (AtFirstTimeStepLUFlag) {
 	      initialLUGridAssignment();
@@ -924,7 +912,7 @@ void tEvapoTrans::callEvapoTrans(tIntercept *Intercept, int flag)
 	cNode = nodeIter.FirstP();
 	while ( nodeIter.IsActive() ) {
 
-	  if (getEToption() == 0 && Intercept->getIoption() == 1) {
+	  if (getEToption() == 0 && Intercept->getIoption() != 0) {
         if (luOption == 1) { 
           if (luInterpOption == 1) {
             interpolateLUGrids(cNode);
@@ -1014,31 +1002,12 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 		rs = stomResist();
 		transFactor = (cc + psy)/(cc + psy*(1+rs/ra));
 		
-		// Code block modified to accoutn for changes to evapWetCanopy calculation in tIntercept:InterceptRutter CJC2025
 		// Check if the interception scheme is turned on
 		if ( flag && (coeffV > 0) && Intercept->IsThereCanopy( cNode )) {
-			// Get quantities and make checks depending on Interception model
 			if (Ioption == 1) {
-				CanStorage = cNode->getCumIntercept();
-				// Evaporation from Wet Canopy
-				if (CanStorage >= potEvaporation*timer->getEtIStep())
-					evapWetCanopy = potEvaporation;
-				else {
-					evapWetCanopy = CanStorage/timer->getEtIStep(); 
-				}
-
-				// Sanity Check
-				if (evapWetCanopy > potEvaporation) {
-					evapWetCanopy = potEvaporation;
-				}
-
-				// Call to Interception  Model
+				// Call Rutter interception model
 				Intercept->callInterception(cNode, potEvaporation);
-			}
-			else if (Ioption == 2) {
-				// Call to Interception  Model
-				Intercept->callInterception(cNode, potEvaporation);
-				// Retrieve wet can evap rate calculated by the rutter interception model.
+				// Retrieve wet canopy evap rate calculated by the Rutter model.
 				evapWetCanopy = cNode->getEvapWetCanopy(); // sanity check done in tIntercept.cpp
 			}
 		}
@@ -1083,12 +1052,6 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 
 		// Total Evapotranspiration
 		evapoTranspiration = evapWetCanopy + evapDryCanopy + evapSoil;
-		
-		// Assignments
-		if (Ioption == 1) {
-			CanStorage = cNode->getCumIntercept();
-			cNode->setCumIntercept(CanStorage - evapWetCanopy/coeffV*timer->getEtIStep()); 
-		}
 		
 		cNode->setEvapWetCanopy(evapWetCanopy);
 		cNode->setEvapDryCanopy(evapDryCanopy);
@@ -2728,7 +2691,7 @@ void tEvapoTrans::betaFunc(tCNode* cNode)
 
     soilzone_cutoff = cNode->getSoilCutoff();
 
-	//Th_star = landPtr->getLandProp(13);
+	//Th_star = landPtr->getLandProp(11);
 	// Th_star can now be read from a table or gridded CJC2025
 	Th_star = coeffSE;
 
@@ -2791,7 +2754,7 @@ void tEvapoTrans::betaFuncT(tCNode* cNode)
 
     rootzone_cutoff = cNode->getRootCutoff();
 
-	//Th_star = landPtr->getLandProp(14);
+	//Th_star = landPtr->getLandProp(12);
 	// Th_star can now be read from a table or gridded CJC2025
 	Th_star = coeffST;
 
@@ -3499,7 +3462,7 @@ void tEvapoTrans::readHydroMetGrid(char *gridFile)
 ** Reads a file (*.gdf) from LUGRID keyword containing the base names of 
 ** the various input land use parameter grids along with the extension
 ** used for the filename. These follow a string that identifies the line
-** with the parameters (ie. AL,TF,VH,SR,VF,CS,IC,CC,DC,DE,OT,LA). If no data 
+** with the parameters (ie. AL,TF,VH,SR,VF,CC,DC,DE,OT,LA). If no data 
 ** available for any parameters, the string NO_DATA should be input 
 ** instead of the path name and extension name. In this version, a single
 ** value of latitude, longitude and GMT is used for entire grids. The
@@ -3556,8 +3519,6 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 		  		(strcmp(LUgridParamNames[ct],"VH")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"SR")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"VF")!=0) &&
-		  		(strcmp(LUgridParamNames[ct],"CS")!=0) &&
-		  		(strcmp(LUgridParamNames[ct],"IC")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"CC")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"DC")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"DE")!=0) &&
@@ -3567,7 +3528,7 @@ void tEvapoTrans::readLUGrid(char *gridFile)
                 (strcmp(LUgridParamNames[ct],"ST")!=0) ) { // CJC2025
 			
 			Cout << "\nA land use parameter name in the LU gdf file is an unexpected one."<<endl;
-			Cout << "\nExpected variables: AL,TF,VH,SR,VF,CS,IC,CC,DC,DE,OT,LA,SE or ST" << endl;
+			Cout << "\nExpected variables: AL,TF,VH,SR,VF,CC,DC,DE,OT,LA,SE or ST" << endl;
 			Cout << "\tCheck and re-run the program" << endl;
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);
@@ -3741,18 +3702,6 @@ void tEvapoTrans::createVariantLU()
 			SetGridTimeInfoVariables(VegFractGrid, LUgridParamNames[ct]);
 			VegFractGrid->newVariable(LUgridParamNames[ct]);
 		}
-		if (strcmp(LUgridParamNames[ct],"CS")==0) {
-			CanStorParamGrid = new tVariant(gridPtr,respPtr);
-			CanStorParamGrid->setFileNames(LUgridBaseNames[ct], LUgridExtNames[ct]);
-			SetGridTimeInfoVariables(CanStorParamGrid, LUgridParamNames[ct]);
-			CanStorParamGrid->newVariable(LUgridParamNames[ct]);
-		}
-		if (strcmp(LUgridParamNames[ct],"IC")==0) {
-			IntercepCoeffGrid = new tVariant(gridPtr,respPtr);
-			IntercepCoeffGrid->setFileNames(LUgridBaseNames[ct], LUgridExtNames[ct]);
-			SetGridTimeInfoVariables(IntercepCoeffGrid, LUgridParamNames[ct]);
-			IntercepCoeffGrid->newVariable(LUgridParamNames[ct]);
-		}
 		if (strcmp(LUgridParamNames[ct],"CC")==0) {
 			CanFieldCapGrid = new tVariant(gridPtr,respPtr);
 			CanFieldCapGrid->setFileNames(LUgridBaseNames[ct], LUgridExtNames[ct]);
@@ -3836,12 +3785,6 @@ void tEvapoTrans::createStaticVariantLU()
         } else if (paramName == "VF") {
             VegFractGrid = new tVariant(gridPtr, respPtr);
             VegFractGrid->updateLUVarOfPrevGrid("VF", staticFileName);
-        } else if (paramName == "CS") {
-            CanStorParamGrid = new tVariant(gridPtr, respPtr);
-            CanStorParamGrid->updateLUVarOfPrevGrid("CS", staticFileName);
-        } else if (paramName == "IC") {
-            IntercepCoeffGrid = new tVariant(gridPtr, respPtr);
-            IntercepCoeffGrid->updateLUVarOfPrevGrid("IC", staticFileName);
         } else if (paramName == "CC") {
             CanFieldCapGrid = new tVariant(gridPtr, respPtr);
             CanFieldCapGrid->updateLUVarOfPrevGrid("CC", staticFileName);
@@ -4192,36 +4135,6 @@ void tEvapoTrans::initialLUGridAssignment()
         }
       }
     }
-    if (strcmp(LUgridParamNames[ct],"CS")==0) {
-      if ( (timer->getCurrentTime())>(double(CSgridhours[NowTillWhichCSgrid])) && numCSfiles > 1) {
-	while ( (timer->getCurrentTime())>(double(CSgridhours[NowTillWhichCSgrid])) ) {
-	  NowTillWhichCSgrid++;
-	}
-	CanStorParamGrid->updateLUVarOfBothGrids("CS", CSgridFileNames[NowTillWhichCSgrid]);
-	CanStorParamGrid->updateLUVarOfPrevGrid("CS", CSgridFileNames[NowTillWhichCSgrid-1]);
-      }
-      else {
-        CanStorParamGrid->updateLUVarOfPrevGrid("CS", CSgridFileNames[1]);
-        if (luInterpOption == 1) {
-            CanStorParamGrid->updateLUVarOfBothGrids("CS", CSgridFileNames[1]);
-        }
-      }
-    }
-    if (strcmp(LUgridParamNames[ct],"IC")==0) {
-      if ( (timer->getCurrentTime())>(double(ICgridhours[NowTillWhichICgrid])) && numICfiles > 1) {
-	while ( (timer->getCurrentTime())>(double(ICgridhours[NowTillWhichICgrid])) ) {
-	  NowTillWhichICgrid++;
-	}
-	IntercepCoeffGrid->updateLUVarOfBothGrids("IC", ICgridFileNames[NowTillWhichICgrid]);
-	IntercepCoeffGrid->updateLUVarOfPrevGrid("IC", ICgridFileNames[NowTillWhichICgrid-1]);
-      }
-      else {
-        IntercepCoeffGrid->updateLUVarOfPrevGrid("IC", ICgridFileNames[1]);
-        if (luInterpOption == 1) {
-            IntercepCoeffGrid->updateLUVarOfBothGrids("IC", ICgridFileNames[1]);
-        }
-      }
-    }
     if (strcmp(LUgridParamNames[ct],"CC")==0) {
       if ( (timer->getCurrentTime())>(double(CCgridhours[NowTillWhichCCgrid])) && numCCfiles > 1 ) {
 	while ( (timer->getCurrentTime())>(double(CCgridhours[NowTillWhichCCgrid])) ) {
@@ -4413,34 +4326,6 @@ void tEvapoTrans::LUGridAssignment()
 	    }
       }
     }
-    if (strcmp(LUgridParamNames[ct],"CS")==0) {
-      if (numCSfiles <= 1) continue;
-      if (NowTillWhichCSgrid<=numCSfiles) {
-	    if ((timer->getCurrentTime())>(double(CSgridhours[NowTillWhichCSgrid]))) { 
-	      NowTillWhichCSgrid++;
-	      if ((NowTillWhichCSgrid-1)<numCSfiles) {
-	        CanStorParamGrid->updateLUVarOfBothGrids("CS", CSgridFileNames[NowTillWhichCSgrid]);
-	      }
-	      else {
-	        CanStorParamGrid->updateLUVarOfPrevGrid("CS", CSgridFileNames[numCSfiles]);
-	      }	
-	    }
-      }
-    }
-    if (strcmp(LUgridParamNames[ct],"IC")==0) {
-      if (numICfiles <= 1) continue;
-      if (NowTillWhichICgrid<=numICfiles) {
-	    if ((timer->getCurrentTime())>(double(ICgridhours[NowTillWhichICgrid]))) { 
-	      NowTillWhichICgrid++;
-	      if ((NowTillWhichICgrid-1)<numICfiles) {
-	        IntercepCoeffGrid->updateLUVarOfBothGrids("IC", ICgridFileNames[NowTillWhichICgrid]);
-	      }
-	      else {
-	        IntercepCoeffGrid->updateLUVarOfPrevGrid("IC", ICgridFileNames[numICfiles]);
-	      }
-	    }
-      }
-    }
     if (strcmp(LUgridParamNames[ct],"CC")==0) {
       if (numCCfiles <= 1) continue;
       if (NowTillWhichCCgrid<=numCCfiles) {
@@ -4613,28 +4498,6 @@ void tEvapoTrans::interpolateLUGrids(tCNode* cNode)
 								(double(VFgridhours[NowTillWhichVFgrid]) - double(VFgridhours[NowTillWhichVFgrid - 1])));
 		}
 	}
-	if (strcmp(LUgridParamNames[ct], "CS") == 0) {
-		if (NowTillWhichCSgrid > numCSfiles) {
-			cNode->setCanStorParam(cNode->getCanStorParamInPrevGrid());
-		}
-		else if ((NowTillWhichCSgrid > 1) && (NowTillWhichCSgrid <= numCSfiles)) {
-			cNode->setCanStorParam(cNode->getCanStorParamInPrevGrid() +
-								(cNode->getCanStorParamInUntilGrid() - cNode->getCanStorParamInPrevGrid()) *
-								(timer->getCurrentTime() - double(CSgridhours[NowTillWhichCSgrid - 1])) /
-								(double(CSgridhours[NowTillWhichCSgrid]) - double(CSgridhours[NowTillWhichCSgrid - 1])));
-		}
-	}
-	if (strcmp(LUgridParamNames[ct], "IC") == 0) {
-		if (NowTillWhichICgrid > numICfiles) {
-			cNode->setIntercepCoeff(cNode->getIntercepCoeffInPrevGrid());
-		}
-		else if ((NowTillWhichICgrid > 1) && (NowTillWhichICgrid <= numICfiles)) {
-			cNode->setIntercepCoeff(cNode->getIntercepCoeffInPrevGrid() +
-								(cNode->getIntercepCoeffInUntilGrid() - cNode->getIntercepCoeffInPrevGrid()) *
-								(timer->getCurrentTime() - double(ICgridhours[NowTillWhichICgrid - 1])) /
-								(double(ICgridhours[NowTillWhichICgrid]) - double(ICgridhours[NowTillWhichICgrid - 1])));
-		}
-	}
 	if (strcmp(LUgridParamNames[ct], "CC") == 0) {
 		if (NowTillWhichCCgrid > numCCfiles) {
 			cNode->setCanFieldCap(cNode->getCanFieldCapInPrevGrid());
@@ -4747,14 +4610,6 @@ void tEvapoTrans::constantLUGrids(tCNode* cNode)
         {
             cNode->setVegFraction( cNode->getVegFractionInPrevGrid() );
         }
-        if ( (strcmp(LUgridParamNames[ct],"CS")==0))
-        {
-            cNode->setCanStorParam( cNode->getCanStorParamInPrevGrid());
-        }
-        if ( (strcmp(LUgridParamNames[ct],"IC")==0))
-        {
-            cNode->setIntercepCoeff( cNode->getIntercepCoeffInPrevGrid());
-        }
         if ( (strcmp(LUgridParamNames[ct],"CC")==0))
         {
             cNode->setCanFieldCap( cNode->getCanFieldCapInPrevGrid());
@@ -4828,18 +4683,6 @@ void tEvapoTrans::integratedLUVars(tCNode* cNode, double te){
       else if (te > 1.0) 
 	cNode->setAvVegFraction((cNode->getAvVegFraction()*(te-1.0) + cNode->getVegFraction())/te);
     }
-    if (strcmp(LUgridParamNames[ct],"CS")==0) {  
-      if (fabs(te - 1.0) < 1.0E-6)
-	cNode->setAvCanStorParam(cNode->getCanStorParam());
-      else if (te > 1.0) 
-	cNode->setAvCanStorParam((cNode->getAvCanStorParam()*(te-1.0) + cNode->getCanStorParam())/te);
-    }
-    if (strcmp(LUgridParamNames[ct],"IC")==0) {  
-      if (fabs(te - 1.0) < 1.0E-6)
-	cNode->setAvIntercepCoeff(cNode->getIntercepCoeff());
-      else if (te > 1.0) 
-	cNode->setAvIntercepCoeff((cNode->getAvIntercepCoeff()*(te-1.0) + cNode->getIntercepCoeff())/te);
-    }
     if (strcmp(LUgridParamNames[ct],"CC")==0) {  
       if (fabs(te - 1.0) < 1.0E-6)
 	cNode->setAvCanFieldCap(cNode->getCanFieldCap());
@@ -4911,8 +4754,6 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 	else if (strcmp(LUgridParamName,"VH")==0) {numVHfiles = 0;}
 	else if (strcmp(LUgridParamName,"SR")==0) {numSRfiles = 0;}
 	else if (strcmp(LUgridParamName,"VF")==0) {numVFfiles = 0;}
-	else if (strcmp(LUgridParamName,"CS")==0) {numCSfiles = 0;}
-	else if (strcmp(LUgridParamName,"IC")==0) {numICfiles = 0;}
 	else if (strcmp(LUgridParamName,"CC")==0) {numCCfiles = 0;}
 	else if (strcmp(LUgridParamName,"DC")==0) {numDCfiles = 0;}
 	else if (strcmp(LUgridParamName,"DE")==0) {numDEfiles = 0;}
@@ -4941,8 +4782,6 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 			else if (strcmp(LUgridParamName,"VH")==0) {numVHfiles++;}
 			else if (strcmp(LUgridParamName,"SR")==0) {numSRfiles++;}
 			else if (strcmp(LUgridParamName,"VF")==0) {numVFfiles++;}
-			else if (strcmp(LUgridParamName,"CS")==0) {numCSfiles++;}
-			else if (strcmp(LUgridParamName,"IC")==0) {numICfiles++;}
 			else if (strcmp(LUgridParamName,"CC")==0) {numCCfiles++;}
 			else if (strcmp(LUgridParamName,"DC")==0) {numDCfiles++;}
 			else if (strcmp(LUgridParamName,"DE")==0) {numDEfiles++;}
@@ -5028,20 +4867,6 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 		VFgridFileNames = new char*[numVFfiles+1];
 		for (int ct=0;ct<numVFfiles+1;ct++) {
 			VFgridFileNames[ct]=new char[kName];
-		}
-	}
-	else if (strcmp(LUgridParamName,"CS")==0) {
-		CSgridhours = new int [numCSfiles+1];
-		CSgridFileNames = new char*[numCSfiles+1];
-		for (int ct=0;ct<numCSfiles+1;ct++) {
-			CSgridFileNames[ct]=new char[kName];
-		}
-	}
-	else if (strcmp(LUgridParamName,"IC")==0) {
-		ICgridhours = new int [numICfiles+1];
-		ICgridFileNames = new char*[numICfiles+1];
-		for (int ct=0;ct<numICfiles+1;ct++) {
-			ICgridFileNames[ct]=new char[kName];
 		}
 	}
 	else if (strcmp(LUgridParamName,"CC")==0) {
@@ -5136,14 +4961,6 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 				VFgridhours[GridHourCounter]=currentTimeLU;
 				strcpy(VFgridFileNames[GridHourCounter],VariantLU->fileIn);
 			}
-			else if (strcmp(LUgridParamName,"CS")==0) {
-				CSgridhours[GridHourCounter]=currentTimeLU;
-				strcpy(CSgridFileNames[GridHourCounter],VariantLU->fileIn);
-			}
-			else if (strcmp(LUgridParamName,"IC")==0) {
-				ICgridhours[GridHourCounter]=currentTimeLU;
-				strcpy(ICgridFileNames[GridHourCounter],VariantLU->fileIn);
-			}
 			else if (strcmp(LUgridParamName,"CC")==0) {
 				CCgridhours[GridHourCounter]=currentTimeLU;
 				strcpy(CCgridFileNames[GridHourCounter],VariantLU->fileIn);
@@ -5201,8 +5018,6 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 	else if (strcmp(LUgridParamName,"VH")==0) {NowTillWhichVHgrid = 1;}
 	else if (strcmp(LUgridParamName,"SR")==0) {NowTillWhichSRgrid = 1;}
 	else if (strcmp(LUgridParamName,"VF")==0) {NowTillWhichVFgrid = 1;}
-	else if (strcmp(LUgridParamName,"CS")==0) {NowTillWhichCSgrid = 1;}
-	else if (strcmp(LUgridParamName,"IC")==0) {NowTillWhichICgrid = 1;}
 	else if (strcmp(LUgridParamName,"CC")==0) {NowTillWhichCCgrid = 1;}
 	else if (strcmp(LUgridParamName,"DC")==0) {NowTillWhichDCgrid = 1;}
 	else if (strcmp(LUgridParamName,"DE")==0) {NowTillWhichDEgrid = 1;}
@@ -5264,22 +5079,6 @@ void tEvapoTrans::deleteLUGrids()
 	    delete [] VFgridFileNames[sz];
 	  }
 	  delete [] VFgridFileNames;
-	}
-	if (strcmp(LUgridParamNames[ct],"CS")==0) {
-	  delete CanStorParamGrid;
-	  delete [] CSgridhours;
-	  for (int sz=0;sz<numCSfiles+1;sz++) {
-	    delete [] CSgridFileNames[sz];
-	  }
-	  delete [] CSgridFileNames;
-	}
-	if (strcmp(LUgridParamNames[ct],"IC")==0) {
-	  delete IntercepCoeffGrid;
-	  delete [] ICgridhours;
-	  for (int sz=0;sz<numICfiles+1;sz++) {
-	    delete [] ICgridFileNames[sz];
-	  }
-	  delete [] ICgridFileNames;					
 	}
 	if (strcmp(LUgridParamNames[ct],"CC")==0) {
 	  delete CanFieldCapGrid;
@@ -5523,8 +5322,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
     BinaryWrite(rStr, NowTillWhichVHgrid); // Ara Ko 2017
     BinaryWrite(rStr, NowTillWhichSRgrid); // Ara Ko 2017
     BinaryWrite(rStr, NowTillWhichVFgrid); // Ara Ko 2017
-    BinaryWrite(rStr, NowTillWhichCSgrid); // Ara Ko 2017
-    BinaryWrite(rStr, NowTillWhichICgrid); // Ara Ko 2017
     BinaryWrite(rStr, NowTillWhichCCgrid); // Ara Ko 2017
     BinaryWrite(rStr, NowTillWhichDCgrid); // Ara Ko 2017
     BinaryWrite(rStr, NowTillWhichDEgrid); // Ara Ko 2017
@@ -5691,8 +5488,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
   BinaryRead(rStr, NowTillWhichVHgrid); // Ara Ko 2017
   BinaryRead(rStr, NowTillWhichSRgrid); // Ara Ko 2017
   BinaryRead(rStr, NowTillWhichVFgrid); // Ara Ko 2017
-  BinaryRead(rStr, NowTillWhichCSgrid); // Ara Ko 2017
-  BinaryRead(rStr, NowTillWhichICgrid); // Ara Ko 2017
   BinaryRead(rStr, NowTillWhichCCgrid); // Ara Ko 2017
   BinaryRead(rStr, NowTillWhichDCgrid); // Ara Ko 2017
   BinaryRead(rStr, NowTillWhichDEgrid); // Ara Ko 2017

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -211,26 +211,25 @@ class tEvapoTrans
   tVariant *StomResGrid, *VegFractGrid; 
 
   // SKYnGM2008LU
-  tVariant *CanStorParamGrid; 
-  tVariant *IntercepCoeffGrid, *CanFieldCapGrid, *DrainCoeffGrid;
+  tVariant *CanFieldCapGrid, *DrainCoeffGrid;
   tVariant *DrainExpParGrid, *OptTransmCoeffGrid, *LeafAIGrid;
   tVariant *EvapThreshGrid, *TransThreshGrid; // CJC2025
 
   // SKYnGM2008LU
   int numALfiles{}, numTFfiles{}, numVHfiles{}, numSRfiles{};
-  int numVFfiles{}, numCSfiles{}, numICfiles{}, numCCfiles{};
+  int numVFfiles{}, numCCfiles{};
   int numDCfiles{}, numDEfiles{}, numOTfiles{}, numLAfiles{};
-  int numSEfiles{}, numSTfiles{}; // CJC2025 
+  int numSEfiles{}, numSTfiles{}; // CJC2025
   int *ALgridhours, *TFgridhours, *VHgridhours, *SRgridhours;
-  int *VFgridhours, *CSgridhours, *ICgridhours, *CCgridhours;
-  int *DCgridhours, *DEgridhours, *OTgridhours, *LAgridhours;  
+  int *VFgridhours, *CCgridhours;
+  int *DCgridhours, *DEgridhours, *OTgridhours, *LAgridhours;
   int *SEgridhours, *STgridhours; // CJC2025
   int NowTillWhichALgrid{}, NowTillWhichTFgrid{}, NowTillWhichVHgrid{}, NowTillWhichSRgrid{};
-  int NowTillWhichVFgrid{}, NowTillWhichCSgrid{}, NowTillWhichICgrid{}, NowTillWhichCCgrid{};
+  int NowTillWhichVFgrid{}, NowTillWhichCCgrid{};
   int NowTillWhichDCgrid{}, NowTillWhichDEgrid{}, NowTillWhichOTgrid{}, NowTillWhichLAgrid{};
   int NowTillWhichSEgrid{}, NowTillWhichSTgrid{}; // CJC2025
   char **ALgridFileNames, **TFgridFileNames, **VHgridFileNames, **SRgridFileNames;
-  char **VFgridFileNames, **CSgridFileNames, **ICgridFileNames, **CCgridFileNames;
+  char **VFgridFileNames, **CCgridFileNames;
   char **DCgridFileNames, **DEgridFileNames, **OTgridFileNames, **LAgridFileNames;
   char **SEgridFileNames, **STgridFileNames; // CJC2025
   int AtFirstTimeStepLUFlag{};

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -428,21 +428,19 @@ void tHydroModel::InitSet(tResample *resamp)
 
 		// SKYnGM2008LU: Land Use Members (for both static and dynamic)
 		landPtr->setLandPtr( cn->getLandUse() );
-		a_LU    = landPtr->getLandProp(1);
-		b1_LU   = landPtr->getLandProp(2);
-		P_LU    = landPtr->getLandProp(3);
-		S_LU    = landPtr->getLandProp(4);
-		K_LU    = landPtr->getLandProp(5);
-		b2_LU   = landPtr->getLandProp(6);
-		Al_LU   = landPtr->getLandProp(7);
-		h_LU    = landPtr->getLandProp(8);
-		Kt_LU   = landPtr->getLandProp(9);
-		Rs_LU   = landPtr->getLandProp(10);
-		V_LU    = landPtr->getLandProp(11);
-		LAI_LU  = landPtr->getLandProp(12);
+		P_LU    = landPtr->getLandProp(1);
+		S_LU    = landPtr->getLandProp(2);
+		K_LU    = landPtr->getLandProp(3);
+		b2_LU   = landPtr->getLandProp(4);
+		Al_LU   = landPtr->getLandProp(5);
+		h_LU    = landPtr->getLandProp(6);
+		Kt_LU   = landPtr->getLandProp(7);
+		Rs_LU   = landPtr->getLandProp(8);
+		V_LU    = landPtr->getLandProp(9);
+		LAI_LU  = landPtr->getLandProp(10);
 		// CJC2025 Stress Thresholds
-		SE_LU   = landPtr->getLandProp(13);
-		ST_LU   = landPtr->getLandProp(14);
+		SE_LU   = landPtr->getLandProp(11);
+		ST_LU   = landPtr->getLandProp(12);
 		cn->setLandUseAlb(Al_LU);
 		cn->setLandUseAlbInPrevGrid(Al_LU);
 		cn->setLandUseAlbInUntilGrid(Al_LU);
@@ -458,12 +456,6 @@ void tHydroModel::InitSet(tResample *resamp)
 		cn->setVegFraction(V_LU);
 		cn->setVegFractionInPrevGrid(V_LU);
 		cn->setVegFractionInUntilGrid(V_LU);
-		cn->setCanStorParam(a_LU);
-		cn->setCanStorParamInPrevGrid(a_LU);
-		cn->setCanStorParamInUntilGrid(a_LU);
-		cn->setIntercepCoeff(b1_LU);
-		cn->setIntercepCoeffInPrevGrid(b1_LU);
-		cn->setIntercepCoeffInUntilGrid(b1_LU);
 		cn->setCanFieldCap(S_LU);
 		cn->setCanFieldCapInPrevGrid(S_LU);
 		cn->setCanFieldCapInUntilGrid(S_LU);
@@ -570,23 +562,19 @@ void tHydroModel::InitIntegralVars()
 
 		// SKYnGM2008LU: Land Use Members (for both static and dynamic)
 		landPtr->setLandPtr( cn->getLandUse() );
-		a_LU    = landPtr->getLandProp(1);
-		b1_LU   = landPtr->getLandProp(2);
-		P_LU    = landPtr->getLandProp(3);
-		S_LU    = landPtr->getLandProp(4);
-		K_LU    = landPtr->getLandProp(5);
-		b2_LU   = landPtr->getLandProp(6);
-		Al_LU   = landPtr->getLandProp(7);
-		h_LU    = landPtr->getLandProp(8);
-		Kt_LU   = landPtr->getLandProp(9);
-		Rs_LU   = landPtr->getLandProp(10);
-		V_LU    = landPtr->getLandProp(11);
-		LAI_LU  = landPtr->getLandProp(12);
+		P_LU    = landPtr->getLandProp(1);
+		S_LU    = landPtr->getLandProp(2);
+		K_LU    = landPtr->getLandProp(3);
+		b2_LU   = landPtr->getLandProp(4);
+		Al_LU   = landPtr->getLandProp(5);
+		h_LU    = landPtr->getLandProp(6);
+		Kt_LU   = landPtr->getLandProp(7);
+		Rs_LU   = landPtr->getLandProp(8);
+		V_LU    = landPtr->getLandProp(9);
+		LAI_LU  = landPtr->getLandProp(10);
 		// CJC2025 Stress Thresholds
-		SE_LU  = landPtr->getLandProp(13);
-		ST_LU  = landPtr->getLandProp(14);
-		cn->setAvCanStorParam(a_LU);
-		cn->setAvIntercepCoeff(b1_LU);
+		SE_LU  = landPtr->getLandProp(11);
+		ST_LU  = landPtr->getLandProp(12);
 		cn->setAvThroughFall(P_LU);
 		cn->setAvCanFieldCap(S_LU);
 		cn->setAvDrainCoeff(K_LU);
@@ -824,11 +812,8 @@ void tHydroModel::UnSaturatedZone(double dt)
 			Ractual = cn->getRain() - EvapSoi - EvapVeg;
 
 		else if (Ioption != 0 && EToption == 0) {
-			if (Ioption != 1) {
-				cout<<"\nError: Cannot Have Rutter Model (on) and ET (off)"<<endl;
-				Ractual = cn->getRain();}
-			else
-				Ractual = cn->getNetPrecipitation();
+			cout<<"\nError: Cannot Have Rutter Model (on) and ET (off)"<<endl;
+			Ractual = cn->getRain();
 		}
 		else if (Ioption != 0 && EToption != 0) {
             Ractual = cn->getNetPrecipitation() - EvapSoi - EvapVeg;
@@ -4467,9 +4452,7 @@ void tHydroModel::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, snowMeltEx);
   BinaryWrite(rStr, swe);
 
-  BinaryWrite(rStr, a_LU);          // land use
-  BinaryWrite(rStr, b1_LU);
-  BinaryWrite(rStr, P_LU);
+  BinaryWrite(rStr, P_LU);          // land use
   BinaryWrite(rStr, S_LU);
   BinaryWrite(rStr, K_LU);
   BinaryWrite(rStr, b2_LU);
@@ -4565,9 +4548,7 @@ void tHydroModel::readRestart(fstream & rStr)
   BinaryRead(rStr, snowMeltEx);
   BinaryRead(rStr, swe);
 
-  BinaryRead(rStr, a_LU);          // land use
-  BinaryRead(rStr, b1_LU);
-  BinaryRead(rStr, P_LU);
+  BinaryRead(rStr, P_LU);          // land use
   BinaryRead(rStr, S_LU);
   BinaryRead(rStr, K_LU);
   BinaryRead(rStr, b2_LU);

--- a/src/tHydro/tHydroModel.h
+++ b/src/tHydro/tHydroModel.h
@@ -176,8 +176,6 @@ private:
   double TotRain{}; 			// Cumulative rainfall value M^3
 
   // SKYnGM2008LU: Land Use Parameters
-  double a_LU{};
-  double b1_LU{};
   double P_LU{};
   double S_LU{};
   double K_LU{};

--- a/src/tHydro/tIntercept.cpp
+++ b/src/tHydro/tIntercept.cpp
@@ -41,6 +41,15 @@ tIntercept::tIntercept(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 void tIntercept::SetIntercpVariables(tInputFile &inFile, tHydroModel *hydro)
 {
 	interceptOption = inFile.ReadItem(interceptOption,"OPTINTERCEPT");
+	if (interceptOption != 0 && interceptOption != 1) {
+	    Cout << "\nInterception Option " << interceptOption;
+	    Cout <<" not valid." << endl;
+	    Cout << "\tPlease use :" << endl;
+		cout << "\t\t(0) No Interception" << endl;
+		cout << "\t\t(1) Rutter (1971) Method: Four Parameter Model" << endl;
+	    Cout << "Exiting Program...\n\n"<<endl;
+		exit(1);
+	}
 	maxInterStormPeriod = inFile.ReadItem(maxInterStormPeriod, "INTSTORMMAX");
 	maxInterStormPeriod = maxInterStormPeriod/2;
 	metTime = inFile.ReadItem(metTime, "METSTEP");
@@ -99,10 +108,10 @@ void tIntercept::DeleteIntercept()
 **
 ** tIntercept::readLUGrid() Function
 **
-** Reads a file (*.gdf) from LUGRID keyword containing the base names of 
+** Reads a file (*.gdf) from LUGRID keyword containing the base names of
 ** the various input land use parameter grids along with the extension
 ** used for the filename. These follow a string that identifies the line
-** with the parameters (ie. AL,TF,VH,SR,VF,CS,IC,CC,DC,DE,OT,LA). If no data 
+** with the parameters (ie. AL,TF,VH,SR,VF,CC,DC,DE,OT,LA). If no data
 ** available for any parameters, the string NO_DATA should be input 
 ** instead of the path name and extension name. In this version, a single
 ** value of latitude, longitude and GMT is used for entire grids. The
@@ -169,24 +178,19 @@ void tIntercept::readLUGrid(char *gridFile)
 **
 ** tIntercept::callInterception() Function
 **
-** Sets the Interception Option in the Constructor
 ** Error message for non-valid options in InputFile
-** Calls the appropriate Method InterceptGray() or InterceptRutter()
+** Calls InterceptRutter()
 **
 ***************************************************************************/
 void tIntercept::callInterception(tCNode *cNode, double Ep)
 {
 	if(interceptOption == 1){
-		InterceptGray(cNode);
-	}
-	else if(interceptOption == 2){
 		InterceptRutter(cNode, Ep);
 	}
 	else{
 		cout << "\nInterception Option "<<interceptOption<<" not valid."<<endl;
 		cout << "\tPlease use :" << endl;
-		cout << "\t\t(1) for Gray (1970) Method: Two Parameter Model"<<endl;
-		cout << "\t\t(2) for Rutter (1971) Method: Four Parameter Model"<<endl;
+		cout << "\t\t(1) for Rutter (1971) Method: Four Parameter Model"<<endl;
 		cout << "Exiting Program...\n\n"<<endl;
 		exit(1);
 	}
@@ -202,58 +206,6 @@ void tIntercept::callInterception(tCNode *cNode, double Ep)
 //
 //=========================================================================
 
-
-/***************************************************************************
-**
-** tIntercept::InterceptGray() Function based on Gray(1970) 
-** 	(Also see Bras,1993, p233)
-**
-** Uses coeffA, coeffB as parameters read from Land Use Table
-**
-**    I(t) = R(t)          while cumI <= coeffA    (mm/hr)
-**    I(t) = coeffB*R(t)   while cumI >  coeff
-**
-***************************************************************************/
-void tIntercept::InterceptGray(tCNode *cNode)
-{ 
-	double cumIntercept, intercept, rainfall, interStormLength;
-	double netPrecipitation;
-	double minRainAmount = 1.0;
-	
-	SetIntercpParameters( cNode );
-	
-	
-	
-	rainfall = cNode->getRain();
-	
-	if (rainfall <= minRainAmount)                //Modify InterStorm Length
-		cNode->setStormLength(1, timer->getEtIStep());
-	else
-		cNode->setStormLength(0, 0);
-	
-	cumIntercept = cNode->getCumIntercept();      //Calculate Interception
-	
-	if (cumIntercept <= coeffA)
-		intercept = rainfall;   
-	else
-		intercept = rainfall*coeffB;
-	
-	cNode->setInterceptLoss(intercept);           //For the _VEGETATED_ fract
-	
-	interStormLength = cNode->getStormLength();   //Set Cumulative Interception
-	
-	if (interStormLength < maxInterStormPeriod)   //For the _VEGETATED_ fract
-		cNode->setCumIntercept(cumIntercept+intercept*timer->getEtIStep());
-	else
-		cNode->setCumIntercept(0.0);
-	
-	// Rate for the _ENTIRE_ cell:
-	netPrecipitation = coeffV*(rainfall-intercept) + (1-coeffV)*rainfall;
-	
-	cNode->setNetPrecipitation(netPrecipitation); //Assign Net Precipitation
-	
-	return;
-}
 
 /***************************************************************************
 **
@@ -477,55 +429,40 @@ double tIntercept::storageRungeKutta(double prevStore, double R, double Ep,
 void tIntercept::SetIntercpParameters(tCNode *cNode)
 {
 	landPtr->setLandPtr(cNode->getLandUse());
-	
+
 	if (interceptOption == 1) {
-		coeffA = landPtr->getLandProp(1);  //Storage Capacity
-		coeffB = landPtr->getLandProp(2);  //Interception Coefficient
-		coeffV = landPtr->getLandProp(11); //Vegetation Fraction 
-	}
-	else if (interceptOption == 2) {
-		coeffP = landPtr->getLandProp(3);          //Free Throughfall Coefficient
-		coeffS = landPtr->getLandProp(4);          //Canopy Storage Capacity
-		coeffK = landPtr->getLandProp(5);          //Drainage Coefficient
-		coeffb = landPtr->getLandProp(6);          //Drainage Exponential Parameter
-		coeffV = landPtr->getLandProp(11);         //Vegetation Fraction 
+		coeffP = landPtr->getLandProp(1);  //Free Throughfall Coefficient
+		coeffS = landPtr->getLandProp(2);  //Canopy Storage Capacity
+		coeffK = landPtr->getLandProp(3);  //Drainage Coefficient
+		coeffb = landPtr->getLandProp(4);  //Drainage Exponential Parameter
+		coeffV = landPtr->getLandProp(9);  //Vegetation Fraction
 	}
 
 	if (luOption == 1 || luOption == 2) {
-		for (int ct=0;ct<nParmLU;ct++) { 
-			if (strcmp(LUgridParamNames[ct],"CS")==0) {
-				if (interceptOption == 1) {
-					coeffA = cNode->getCanStorParam();  //Canopy Storage Parameter
-				}
-			}
-			if (strcmp(LUgridParamNames[ct],"IC")==0) {
-				if (interceptOption == 1) {
-					coeffB = cNode->getIntercepCoeff();  //Interception Coefficient
-				}
-			}
+		for (int ct=0;ct<nParmLU;ct++) {
 			if (strcmp(LUgridParamNames[ct],"TF")==0) {
-				if (interceptOption == 2) {
+				if (interceptOption == 1) {
 					coeffP = cNode->getThroughFall();  //Free Throughfall Coefficient
 				}
 			}
 			if (strcmp(LUgridParamNames[ct],"CC")==0) {
-				if (interceptOption == 2) {
+				if (interceptOption == 1) {
 					coeffS = cNode->getCanFieldCap();  //Canopy Storage Capacity
 				}
 			}
 			if (strcmp(LUgridParamNames[ct],"DC")==0) {
-				if (interceptOption == 2) {
+				if (interceptOption == 1) {
 					coeffK = cNode->getDrainCoeff();  //Drainage Coefficient
 				}
 			}
 			if (strcmp(LUgridParamNames[ct],"DE")==0) {
-				if (interceptOption == 2) {
+				if (interceptOption == 1) {
 					coeffb = cNode->getDrainExpPar();  //Drainage Exponential Parameter
 				}
 			}
 			if (strcmp(LUgridParamNames[ct],"VF")==0) {
-				if ( (interceptOption == 1) || (interceptOption == 2) ) {
-					coeffV = cNode->getVegFraction();  //Vegetation Fraction 
+				if (interceptOption == 1) {
+					coeffV = cNode->getVegFraction();  //Vegetation Fraction
 				}
 			}
 		}
@@ -554,11 +491,9 @@ int tIntercept::getIoption()
 double tIntercept::getCtoS(tCNode *cNode)
 {
 	double ctos {};
-	if (interceptOption == 1)
-		ctos = 1;
-	else if (interceptOption == 2) {
+	if (interceptOption == 1) {
 		landPtr->setLandPtr(cNode->getLandUse());
-		coeffS = landPtr->getLandProp(4);          //Canopy Field Capacity
+		coeffS = landPtr->getLandProp(2);  //Canopy Field Capacity
 		ctos = cNode->getCanStorage()/coeffS;
 	}
 	return ctos;
@@ -574,14 +509,12 @@ double tIntercept::getCtoS(tCNode *cNode)
 int tIntercept::IsThereCanopy(tCNode *cNode)
 {
 	int answer {};
-	if (interceptOption == 1)
-		answer = 1;
-	else if (interceptOption == 2) {
+	if (interceptOption == 1) {
 		landPtr->setLandPtr(cNode->getLandUse());
-		coeffP = landPtr->getLandProp(3);       //Free Throughfall Coefficient
+		coeffP = landPtr->getLandProp(1);  //Free Throughfall Coefficient
 		if (coeffP < 0.999)
 			answer = 1;
-		else 
+		else
 			answer = 0;
 	}
 	return answer;
@@ -599,8 +532,6 @@ void tIntercept::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, interceptOption);
   BinaryWrite(rStr, maxInterStormPeriod);
   BinaryWrite(rStr, metTime);
-  BinaryWrite(rStr, coeffA);
-  BinaryWrite(rStr, coeffB);
   BinaryWrite(rStr, coeffP);
   BinaryWrite(rStr, coeffS);
   BinaryWrite(rStr, coeffK);
@@ -618,8 +549,6 @@ void tIntercept::readRestart(fstream & rStr)
   BinaryRead(rStr, interceptOption);
   BinaryRead(rStr, maxInterStormPeriod);
   BinaryRead(rStr, metTime);
-  BinaryRead(rStr, coeffA);
-  BinaryRead(rStr, coeffB);
   BinaryRead(rStr, coeffP);
   BinaryRead(rStr, coeffS);
   BinaryRead(rStr, coeffK);

--- a/src/tHydro/tIntercept.h
+++ b/src/tHydro/tIntercept.h
@@ -9,11 +9,11 @@
 
 /***************************************************************************
 **
-**  tIntercept.h: Header file for class tIntercept 
+**  tIntercept.h: Header file for class tIntercept
 **
 **  This class encapsulates the rainfall interception routines
-**  necessary for net precipitation computations. Two interception methods
-**  are currently implemented based on Gray (1970) and Rutter et al (1971).
+**  necessary for net precipitation computations. Interception is computed
+**  using the Rutter et al (1971) method.
 **
 ***************************************************************************/
 
@@ -42,7 +42,6 @@ class tIntercept
   int    getIoption();
   int    IsThereCanopy(tCNode *);
   void   callInterception(tCNode *, double);
-  void   InterceptGray(tCNode *);
   void   InterceptRutter(tCNode *, double);
   void   SetIntercpParameters(tCNode *);
   void   SetIntercpVariables(tInputFile&, tHydroModel*);
@@ -71,9 +70,8 @@ class tIntercept
 
   int maxInterStormPeriod;
   double metTime;
-  double coeffA, coeffB;                 //Gray model 
   double coeffP, coeffS, coeffK, coeffb; //Rutter model
-  double coeffV;                         //Both models
+  double coeffV;
 };
 
 #endif

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -368,21 +368,6 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
     while (nodeIter.IsActive()) {
         double precip = 0.0;
 
-        // CJC2025 this block was overwriting land use parameters when it is not needed
-        /* landPtr->setLandPtr(cNode->getLandUse());
-        cNode->setCanStorParam(landPtr->getLandProp(1));
-        cNode->setIntercepCoeff(landPtr->getLandProp(2));
-        cNode->setThroughFall(landPtr->getLandProp(3));
-        cNode->setCanFieldCap(landPtr->getLandProp(4));
-        cNode->setDrainCoeff(landPtr->getLandProp(5));
-        cNode->setDrainExpPar(landPtr->getLandProp(6));
-        cNode->setLandUseAlb(landPtr->getLandProp(7));
-        cNode->setVegHeight(landPtr->getLandProp(8));
-        cNode->setOptTransmCoeff(landPtr->getLandProp(9));
-        cNode->setStomRes(landPtr->getLandProp(10));
-        cNode->setVegFraction(landPtr->getLandProp(11));
-        cNode->setLeafAI(landPtr->getLandProp(12)); */
-
         // Elapsed MET steps from the beginning, used for averaging dynamic LU grid values below over time for integ. output
         auto te = (double) timer->getElapsedMETSteps(timer->getCurrentTime());
         integratedLUVars(cNode, te);

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -352,18 +352,16 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				<<"Srf_Hour_mm " //71
 				<<"Qstrm_m3_s " //72
 				<<"Hlevel_m " //73
-				<<"CanStorParam_mm " //74
-				<<"IntercepCoeff_[] " //75
-				<<"ThroughFall_[] " //76
-				<<"CanFieldCap_mm " //77
-				<<"DrainCoeff_mm_hr " //78
-				<<"DrainExpPar_1_mm " //78
-				<<"LandUseAlb_[] " //80
-				<<"VegHeight_m " //81
-				<<"OptTransmCoeff_[] " //82
-				<<"StomRes_s_m " //83
-				<<"VegFraction[] " //84
-				<<"LeafAI_[] " //85
+				<<"ThroughFall_[] " //74
+				<<"CanFieldCap_mm " //75
+				<<"DrainCoeff_mm_hr " //76
+				<<"DrainExpPar_1_mm " //77
+				<<"LandUseAlb_[] " //78
+				<<"VegHeight_m " //79
+				<<"OptTransmCoeff_[] " //80
+				<<"StomRes_s_m " //81
+				<<"VegFraction[] " //82
+				<<"LeafAI_[] " //83
 				<<"\n";
 				
 				pixinfo[i].setf( ios::right, ios::adjustfield );
@@ -1062,8 +1060,6 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 				
 				// SKYnGM2008LU
 				this->pixinfo[i]<<setprecision(7)
-				<<setw(10)<<this->uzel[i]->getCanStorParam()<<" "
-				/* 75 */ << this->uzel[i]->getIntercepCoeff()<<" "
 				<< this->uzel[i]->getThroughFall()<<" "
 				<< this->uzel[i]->getCanFieldCap()<<" "
 				<< this->uzel[i]->getDrainCoeff()<<" "
@@ -1156,18 +1152,16 @@ void tCOutput<tSubNode>::WriteDynamicVars( double time )
 			<< "Qstrm" << ','          // 39
 			<< "Hlev" << ','           // 40
 			<< "FlwVlc" << ','         // 41
-			<< "CanStorParam" << ','   // 42
-			<< "IntercepCoeff" << ','  // 43
-			<< "ThroughFall" << ','    // 44
-			<< "CanFieldCap" << ','    // 45
-			<< "DrainCoeff" << ','     // 46
-			<< "DrainExpPar" << ','    // 47
-			<< "LandUseAlb" << ','     // 48
-			<< "VegHeight" << ','      // 49
-			<< "OptTransmCoeff" << ',' // 50
-			<< "StomRes" << ','        // 51
-			<< "VegFraction" << ','    // 52
-			<< "LeafAI";               // 53
+			<< "ThroughFall" << ','    // 42
+			<< "CanFieldCap" << ','    // 43
+			<< "DrainCoeff" << ','     // 44
+			<< "DrainExpPar" << ','    // 45
+			<< "LandUseAlb" << ','     // 46
+			<< "VegHeight" << ','      // 47
+			<< "OptTransmCoeff" << ',' // 48
+			<< "StomRes" << ','        // 49
+			<< "VegFraction" << ','    // 50
+			<< "LeafAI";               // 51
 
 	if (time == 0)
 		arcofs << ',' << "SoilID" << ',' << "LUseID" << endl << flush;
@@ -1225,18 +1219,16 @@ void tCOutput<tSubNode>::WriteDynamicVars( double time )
                << setprecision(3) << cn->getQstrm() << ','                          // 39
                << setprecision(3) << cn->getHlevel() << ','                         // 40
                << setprecision(3) << cn->getFlowVelocity() << ','                   // 41
-               << setprecision(5) << cn->getCanStorParam() << ','                   // 42 , meaning of life?
-               << setprecision(5) << cn->getIntercepCoeff() << ','                  // 43
-               << setprecision(5) << cn->getThroughFall() << ','                    // 44
-               << setprecision(5) << cn->getCanFieldCap() << ','                    // 45
-               << setprecision(5) << cn->getDrainCoeff() << ','                     // 46
-               << setprecision(5) << cn->getDrainExpPar() << ','                    // 47
-               << setprecision(5) << cn->getLandUseAlb() << ','                     // 48
-               << setprecision(5) << cn->getVegHeight() << ','                      // 49
-               << setprecision(5) << cn->getOptTransmCoeff() << ','                 // 50
-               << setprecision(5) << cn->getStomRes() << ','                        // 51
-               << setprecision(5) << cn->getVegFraction() << ','                    // 52
-               << setprecision(5) << cn->getLeafAI();                               // 53
+               << setprecision(5) << cn->getThroughFall() << ','                    // 42
+               << setprecision(5) << cn->getCanFieldCap() << ','                    // 43
+               << setprecision(5) << cn->getDrainCoeff() << ','                     // 44
+               << setprecision(5) << cn->getDrainExpPar() << ','                    // 45
+               << setprecision(5) << cn->getLandUseAlb() << ','                     // 46
+               << setprecision(5) << cn->getVegHeight() << ','                      // 47
+               << setprecision(5) << cn->getOptTransmCoeff() << ','                 // 48
+               << setprecision(5) << cn->getStomRes() << ','                        // 49
+               << setprecision(5) << cn->getVegFraction() << ','                    // 50
+               << setprecision(5) << cn->getLeafAI();                               // 51
 
         if (time == 0)
             arcofs << ',' << setprecision(0) << cn->getSoilID() << ','
@@ -1330,34 +1322,32 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 		   << "cSnSub" << ','    // 45
 		   << "cSnEvap" << ','    // 46
 		   << "cIntUnl" << ','    // 47
-		   << "AvCanStorParam" << ','    // 48
-		   << "AvIntercCoeff" << ','    // 49
-		   << "AvTF" << ','    // 50
-		   << "AvCanFieldCap" << ','    // 51
-		   << "AvDrainCoeff" << ','    // 52
-		   << "AvDrainExpPar" << ','    // 53
-		   << "AvLUAlb" << ','    // 54
-		   << "AvVegHeight" << ','    // 55
-		   << "AvOTCoeff" << ','    // 56
-		   << "AvStomRes" << ','    // 57
-		   << "AvVegFract" << ','    // 58
-		   << "AvLeafAI" << ','    // 59
-		   << "AvEvapThresh" << ','    // 60
-		   << "AvTransThresh"    // 61
-		   << ',' << "Bedrock_Depth_mm"    // 62
-		   << ',' << "Ks"    // 63
-		   << ',' << "ThetaS"    // 64
-		   << ',' << "ThetaR"    // 65
-		   << ',' << "PoreSize"    // 66
-		   << ',' << "AirEBubPress"    // 67
-		   << ',' << "DecayF"    // 67
-		   << ',' << "SatAnRatio"    // 69
-		   << ',' << "UnsatAnRatio"    // 70
-		   << ',' << "Porosity"    // 71
-		   << ',' << "VolHeatCond"    // 72
-		   << ',' << "SoilHeatCap"    // 73
-		   << ',' << "SoilID"    // 74
-		   << ',' << "LandUseID"    // 75
+		   << "AvTF" << ','    // 48
+		   << "AvCanFieldCap" << ','    // 49
+		   << "AvDrainCoeff" << ','    // 50
+		   << "AvDrainExpPar" << ','    // 51
+		   << "AvLUAlb" << ','    // 52
+		   << "AvVegHeight" << ','    // 53
+		   << "AvOTCoeff" << ','    // 54
+		   << "AvStomRes" << ','    // 55
+		   << "AvVegFract" << ','    // 56
+		   << "AvLeafAI" << ','    // 57
+		   << "AvEvapThresh" << ','    // 58
+		   << "AvTransThresh"    // 59
+		   << ',' << "Bedrock_Depth_mm"    // 60
+		   << ',' << "Ks"    // 61
+		   << ',' << "ThetaS"    // 62
+		   << ',' << "ThetaR"    // 63
+		   << ',' << "PoreSize"    // 64
+		   << ',' << "AirEBubPress"    // 65
+		   << ',' << "DecayF"    // 66
+		   << ',' << "SatAnRatio"    // 67
+		   << ',' << "UnsatAnRatio"    // 68
+		   << ',' << "Porosity"    // 69
+		   << ',' << "VolHeatCond"    // 70
+		   << ',' << "SoilHeatCap"    // 71
+		   << ',' << "SoilID"    // 72
+		   << ',' << "LandUseID"    // 73
 		   << "\n";
 	
 	cn = ni.FirstP();
@@ -1467,34 +1457,32 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			<<setprecision(7)<<cn->getCumSnSub()<<','//45
 			<<setprecision(7)<<cn->getCumSnEvap()<<','//46
 			<<setprecision(7)<<cn->getCumIntUnl()<<','//47
-			<<setprecision(7)<<cn->getAvCanStorParam()<<',' //48
-			<<setprecision(7)<<cn->getAvIntercepCoeff()<<',' //49
-			<<setprecision(7)<<cn->getAvThroughFall()<<',' //50
-			<<setprecision(7)<<cn->getAvCanFieldCap()<<',' //51
-			<<setprecision(7)<<cn->getAvDrainCoeff()<<',' //52
-			<<setprecision(7)<<cn->getAvDrainExpPar()<<',' //53
-			<<setprecision(7)<<cn->getAvLandUseAlb()<<',' //54
-			<<setprecision(7)<<cn->getAvVegHeight()<<','  //55
-			<<setprecision(7)<<cn->getAvOptTransmCoeff()<<',' //56
-			<<setprecision(7)<<cn->getAvStomRes()<<',' // 57
-			<<setprecision(7)<<cn->getAvVegFraction()<<',' //58
-			<<setprecision(7)<<cn->getAvLeafAI()<<',' //59
-			<<setprecision(7)<<cn->getAvEvapThresh()<<',' //60
-			<<setprecision(7)<<cn->getAvTransThresh()<<',' //61
-            <<setprecision(7)<<cn->getBedrockDepth()<<',' //62 bedrock depth mm
-           << setprecision(7) << cn->getKs() << ',' // 63
-           << setprecision(7) << cn->getThetaS() << ',' // 64
-           << setprecision(7) << cn->getThetaR() << ',' // 65
-           << setprecision(7) << cn->getPoreSize() << ',' // 66
-           << setprecision(7) << cn->getAirEBubPres() << ',' // 67
-           << setprecision(7) << cn->getDecayF() << ',' // 68
-           << setprecision(7) << cn->getSatAnRatio() << ',' // 69
-           << setprecision(7) << cn->getUnsatAnRatio() << ',' // 70
-           << setprecision(7) << cn->getPorosity() << ',' // 71
-           << setprecision(7) << cn->getVolHeatCond() << ',' // 72
-           << setprecision(7) << cn->getSoilHeatCap() << ',' // 73
-           << setprecision(7) << cn->getSoilID() << ',' //74
-           << setprecision(7) << cn->getLandUse(); // 75
+			<<setprecision(7)<<cn->getAvThroughFall()<<',' //48
+			<<setprecision(7)<<cn->getAvCanFieldCap()<<',' //49
+			<<setprecision(7)<<cn->getAvDrainCoeff()<<',' //50
+			<<setprecision(7)<<cn->getAvDrainExpPar()<<',' //51
+			<<setprecision(7)<<cn->getAvLandUseAlb()<<',' //52
+			<<setprecision(7)<<cn->getAvVegHeight()<<','  //53
+			<<setprecision(7)<<cn->getAvOptTransmCoeff()<<',' //54
+			<<setprecision(7)<<cn->getAvStomRes()<<',' // 55
+			<<setprecision(7)<<cn->getAvVegFraction()<<',' //56
+			<<setprecision(7)<<cn->getAvLeafAI()<<',' //57
+			<<setprecision(7)<<cn->getAvEvapThresh()<<',' //58
+			<<setprecision(7)<<cn->getAvTransThresh()<<',' //59
+            <<setprecision(7)<<cn->getBedrockDepth()<<',' //60 bedrock depth mm
+           << setprecision(7) << cn->getKs() << ',' // 61
+           << setprecision(7) << cn->getThetaS() << ',' // 62
+           << setprecision(7) << cn->getThetaR() << ',' // 63
+           << setprecision(7) << cn->getPoreSize() << ',' // 64
+           << setprecision(7) << cn->getAirEBubPres() << ',' // 65
+           << setprecision(7) << cn->getDecayF() << ',' // 66
+           << setprecision(7) << cn->getSatAnRatio() << ',' // 67
+           << setprecision(7) << cn->getUnsatAnRatio() << ',' // 68
+           << setprecision(7) << cn->getPorosity() << ',' // 69
+           << setprecision(7) << cn->getVolHeatCond() << ',' // 70
+           << setprecision(7) << cn->getSoilHeatCap() << ',' // 71
+           << setprecision(7) << cn->getSoilID() << ',' //72
+           << setprecision(7) << cn->getLandUse(); // 73
 
         intofs<<"\n";
 		

--- a/src/tRasTin/tVariant.cpp
+++ b/src/tRasTin/tVariant.cpp
@@ -202,14 +202,6 @@ void tVariant::updateLUVarOfPrevGrid(const char *param, char *GridFileName)
 			cn->setVegFractionInPrevGrid( resample[id] );
 			cn->setVegFraction( resample[id] );
 		}
-		else if (strcmp(param,"CS") == 0) {
-			cn->setCanStorParamInPrevGrid( resample[id] );
-			cn->setCanStorParam( resample[id] );
-		}
-		else if (strcmp(param,"IC") == 0) {
-			cn->setIntercepCoeffInPrevGrid( resample[id] );
-			cn->setIntercepCoeff( resample[id] );
-		}
 		else if (strcmp(param,"CC") == 0) {
 			cn->setCanFieldCapInPrevGrid( resample[id] );
 			cn->setCanFieldCap( resample[id] );
@@ -294,16 +286,6 @@ void tVariant::updateLUVarOfBothGrids(const char *param, char *GridFileName)
 			cn->setVegFractionInPrevGrid( cn->getVegFractionInUntilGrid() );
 			cn->setVegFraction( cn->getVegFractionInUntilGrid() );
 			cn->setVegFractionInUntilGrid( resample[id] );
-		}
-		else if (strcmp(param,"CS") == 0) {
-			cn->setCanStorParamInPrevGrid( cn->getCanStorParamInUntilGrid() );
-			cn->setCanStorParam( cn->getCanStorParamInUntilGrid() );
-			cn->setCanStorParamInUntilGrid( resample[id] );
-		}
-		else if (strcmp(param,"IC") == 0) {
-			cn->setIntercepCoeffInPrevGrid( cn->getIntercepCoeffInUntilGrid() );
-			cn->setIntercepCoeff( cn->getIntercepCoeffInUntilGrid() );
-			cn->setIntercepCoeffInUntilGrid( resample[id] );
 		}
 		else if (strcmp(param,"CC") == 0) {
 			cn->setCanFieldCapInPrevGrid( cn->getCanFieldCapInUntilGrid() );

--- a/src/tSimulator/tSimul.cpp
+++ b/src/tSimulator/tSimul.cpp
@@ -387,18 +387,11 @@ void Simulator::SurfaceHydroProcesses(tEvapoTrans *EvapoTrans,
 		}
 		// 2) Interception ON
 		if (EvapoTrans->getEToption() == 0 && Intercept->getIoption() != 0) {
-			if (Intercept->getIoption() == 1) {
-				if ( timer->getCurrentTime() == eti_hour )
-					EvapoTrans->callEvapoTrans( Intercept, 1 );
-			}
-			else {
-				Cout<<"\nInterception Option "<<Intercept->getIoption()
-				   <<" not valid if "<<endl;
-				Cout<<"Evaporation scheme turned off. \n\tPlease use:"<<endl;
-				Cout<<"\t\t(1) for Gray (1970) Method: Two Parameter Model"<<endl;
-				Cout<<"Exiting Program...\n\n"<<endl;
-				exit(1);
-			}
+			Cout<<"\nInterception Option "<<Intercept->getIoption()
+				<<" not valid if "<<endl;
+			Cout<<"Evaporation scheme turned off. \n"<<endl;
+			Cout<<"Exiting Program...\n\n"<<endl;
+			exit(1);
 		}
 		// 3) ET ON
 		if (EvapoTrans->getEToption() !=0 && Intercept->getIoption() == 0) {


### PR DESCRIPTION
This pull request merges changes to interception scheme into the `dev` branch, targeting the upcoming v6.0.0 release.

The primary goals of this update are to remove the Gray (1970) interception as the method is no longer commonly used. Removing the method simplifies model inputs and cleans up the codebase.

**Technical Changes (C++ / Inputs)**
*   **Remove Gray Interception:** All functions/variables related to the scheme itself in `tIntercept` and any other locatiosn in the codebase were removed. Additional checks were added to exit the simulation if the user specifies a method other than the Rutter method.

**Input/Output Specification**

**Input Flags**
*   `OPTINTERCEPT` keyword can now only be 0 (interception off) or 1 (Rutter interception) in the main input file. 
*   `LANDTABLENAME` keyword for specifying the path to the land use file in the main input file has not change but the contents of the file have. 

**New Parameter File Structure**
Previously no matter the interception method selected the model required users to include values for the Gray interception method in the land use table leading to a total of 14 parameters for each land use class. The format for the table has not changed but the ordering has. The first two parameters for each class have been removed, thus the first parameter is now the free-throughfall coefficient with the 11 other parameters following in the same order as previous tRIBS versions.