### PR TITLE
fix: Fix Sub hourly Precipitation Forcing in Snow Module

### DIFF
--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -100,8 +100,10 @@ void tSnowPack::SetSnowInterceptVariables() {
 void tSnowPack::SetSnowVariables(tInputFile &infile) {
     
 
-    //time steps
-    timeStepm = infile.ReadItem(timeStepm, "METSTEP");
+    //time steps: use etistep (= min(metstep, dtRain)) so sub-hourly rainfall is
+    //handled correctly. When dtRain >= metstep (the normal hourly case) this is
+    //identical to reading METSTEP directly.
+    timeStepm = timer->getEtIStep() * 60.0;  // hours -> minutes
     timeSteph = timeStepm / 60.0;
     timeSteps = 60.0 * timeStepm;
     minutelyTimeStep = 0.0;

--- a/src/tSimulator/tSimul.cpp
+++ b/src/tSimulator/tSimul.cpp
@@ -412,7 +412,7 @@ void Simulator::SurfaceHydroProcesses(tEvapoTrans *EvapoTrans,
 		// Possible combinations of Evapotrans and Intercept on/off
 		// 1) BOTH ON
 		if (SnowPack->getEToption() !=0 && Intercept->getIoption() != 0) {
-			if ( timer->getCurrentTime() == met_hour ) {
+			if ( timer->getCurrentTime() == eti_hour ) {
 
 				SnowPack->callSnowPack(Intercept,1);
             }
@@ -428,7 +428,7 @@ void Simulator::SurfaceHydroProcesses(tEvapoTrans *EvapoTrans,
 		}
 		// 3) ET ON
 		if (SnowPack->getEToption() !=0 && Intercept->getIoption() == 0) {
-			if ( timer->getCurrentTime() == met_hour ) {
+			if ( timer->getCurrentTime() == eti_hour ) {
 				SnowPack->callSnowPack(Intercept,0);
 			}
 


### PR DESCRIPTION
This pull request fixes a bug in the snow module that resulted in incorrect hydrograph timing when sub-hourly rainfall data is provided, targeting the upcoming v6.0.0 release.                                                     
                                                                                                                                                                                                                                 
When `RAININTRVL` is set to a sub-hourly value (e.g., 0.25 hours for 15-minute data) and the snow module is enabled, precipitation was only processed once per hour rather than at each rainfall interval. This caused net  precipitation and therefore infiltration and runoff to be held constant across all sub-hourly intervals within an hour.
                                                                                                                                                                                                                                 
The root cause was that callSnowPack() was triggered at met_hour intervals (driven by `METSTEP`, usually 1 hour in practice) rather than `eti_hour` intervals (`etistep = min(METSTEP, RAININTRVL`)). The non-snow path correctly called `callEvapoTrans()` at `eti_hour`, but the snow path was never updated to match when sub-hourly rainfall support was added.


**Technical Changes (C++ / Inputs)**  
* tSimul.cpp: In SurfaceHydroProcesses(), the snow path now triggers `callSnowPack() `at `eti_hour` instead of `met_hour` for both the ET+interception ON and ET-only cases. This matches the existing behavior of the non-snow path.
* tSnowPack.cpp: In SetSnowVariables(), the internal snow energy balance timestep is now derived from `timer->getEtIStep()` rather than reading `METSTEP` directly from the input file. This ensures the energy balance integrates fluxes over the correct interval when `callSnowPack()` is called more frequently than once per hour. For the standard hourly case (`RAININTRVL >= METSTEP`), `etistep = metstep` and behavior is identical to before.

**Input Flags**
*   `ETISTEP` keyword is not required. This is not a change in this update but this keyword has not been used by the model since the addition of the snow module. Future versions of the ReadTheDocs Wiki and pytRIBS will have this keyword removed.