### PR TITLE
fix: Issues Related to In-Channel Transmission Losses Routine

### DIFF
--- a/doc/md/TODO.md
+++ b/doc/md/TODO.md
@@ -3,10 +3,9 @@
 ### Todo
 - [ ] Refactor tResample::doIt, code is unclear and possible bottle neck.
 - [ ] Review/remove remaining user run flags
-- [ ] Check if GAUGEBASENAME: Rain Gauge data BASE name (*.mdf) is needed, this is superseded by the .sdf file.
 - [ ] Update flow for reading in dynamic LU grids--this is a bottleneck in terms of speed
-- [ ] Create parameter input file for snowpack.cpp
 - [ ] Consider flexible approach for specifying outputs, I.E. could we make it so that you could pass in attribute related to a node and have them returned in the dynamic and integrated files. Could also be nice for input parameters, i.e. make list of hard coded parameters and expose as inputs.
+- [ ] Resolve remaing bugs in channel transmission losses routine for option 3, green-ampt method.
 ### Finished
 - [x] Finalize updated benchmarks
 - [x] Remove invariant .pixel files--all relevant information can be written to the time integrated variable
@@ -15,6 +14,8 @@
 - [x] Update .in file and inputs, including moving command line flags and unnecessary options in .in files
 - [x] Fix compiler warnings (sprintf to sprintnf, etc ...)
 - [x] Update compiler flags and release version for optimized performance
+- [x] Create parameter input file for snowpack.cpp
+- [x] Check if GAUGEBASENAME: Rain Gauge data BASE name (*.mdf) is needed, this is superseded by the .sdf file.
 
 
 Return to [README](../../README.md)

--- a/doc/md/TODO.md
+++ b/doc/md/TODO.md
@@ -5,7 +5,7 @@
 - [ ] Review/remove remaining user run flags
 - [ ] Update flow for reading in dynamic LU grids--this is a bottleneck in terms of speed
 - [ ] Consider flexible approach for specifying outputs, I.E. could we make it so that you could pass in attribute related to a node and have them returned in the dynamic and integrated files. Could also be nice for input parameters, i.e. make list of hard coded parameters and expose as inputs.
-- [ ] Resolve remaing bugs in channel transmission losses routine for option 3, green-ampt method.
+- [ ] Resolve remaing problems in channel transmission losses routine for option 2 & 3, (transient & green-ampt methods) ([#112](https://github.com/tRIBS-Model/tRIBS/pull/112)).
 ### Finished
 - [x] Finalize updated benchmarks
 - [x] Remove invariant .pixel files--all relevant information can be written to the time integrated variable

--- a/src/tFlowNet/tKinemat.cpp
+++ b/src/tFlowNet/tKinemat.cpp
@@ -65,14 +65,17 @@ tKinemat::tKinemat(SimulationControl *sPtr, tMesh<tCNode> *gridRef, tInputFile &
 
     percolationOption = infile.ReadItem(percolationOption, "OPTPERCOLATION");
     if (percolationOption != 0) {
+        // Conductivity values are read in mm/hr and converted to m/s for internal use.
         ChannelConduc = infile.ReadItem(ChannelConduc, "CHANNELCONDUCTIVITY");
-        channelPorosity = infile.ReadItem(channelPorosity, "CHANNELPOROSITY");
+        ChannelConduc /= (1000.0 * 3600.0);  // mm/hr -> m/s
         if (percolationOption == 2) {
             TransientConduc = infile.ReadItem(TransientConduc, "TRANSIENTCONDUCTIVITY");
+            TransientConduc /= (1000.0 * 3600.0);  // mm/hr -> m/s
             TransientTime = infile.ReadItem(TransientTime, "TRANSIENTTIME");
         } else if (percolationOption == 3) {
             PoreInd = infile.ReadItem(PoreInd, "CHANPOREINDEX");
             PsiB = infile.ReadItem(PsiB, "CHANPSIB");
+            channelPorosity = infile.ReadItem(channelPorosity, "CHANNELPOROSITY");
         }
     }
     IntStormMax = infile.ReadItem(IntStormMax, "INTSTORMMAX"); //ASM
@@ -80,6 +83,20 @@ tKinemat::tKinemat(SimulationControl *sPtr, tMesh<tCNode> *gridRef, tInputFile &
     Cout << "\nChannel Characteristics:" << endl << endl;
     Cout << "Kinematic velocity coefficient: " << kincoef << endl;
     Cout << "Roughness coefficient: \t\t" << Roughness << endl;
+    if (percolationOption != 0) {
+        Cout << "Transmission loss option: \t" << percolationOption << endl;
+        Cout << "Channel conductivity: \t\t" << ChannelConduc * 1000.0 * 3600.0
+             << " mm/hr" << endl;
+        if (percolationOption == 2)
+            Cout << "Transient conductivity: \t" << TransientConduc * 1000.0 * 3600.0
+                 << " mm/hr  (active for " << TransientTime << " hr)" << endl;
+        if (percolationOption == 3) {
+            cout << "\nError: OPTPERCOLATION = 3 (Green-Ampt) is not functional in this "
+                 << "version of tRIBS and has been disabled. Use OPTPERCOLATION = 1 "
+                 << "(constant loss) or OPTPERCOLATION = 2 (transient loss)." << endl;
+            exit(1);
+        }
+    }
 
     Width = infile.ReadItem(Width, "CHANNELWIDTHCOEFF");
     if (Width <= 0.0) {
@@ -777,6 +794,14 @@ void tKinemat::RunRoutingModel(int it, int *check, double timeStep) {
         else
             KinematWave(C, Y1, Y2, Y3, reis, his, qit, H0, check);
 
+        // Clamp computed water depths to zero. Transmission losses can drive depths
+        // slightly negative during low-flow conditions. Negative depths cause pow(h, 5/3) to produce NaN.
+        // This "post-solve clamp" is a practical approach. The alternative would be bounding
+        // res[i] more tightly before solving so depths never go below zero but we would have 
+        // to know the available water volume per link in advance i.e. its circular.
+        for (int i = 0; i < n; i++)
+            if (his[i] < 0.0) his[i] = 0.0;
+
         // Update computed values of levels & Qs
 
 /********************* Start of modifications by JECR 2015 **************************/
@@ -1071,23 +1096,25 @@ void tKinemat::InitializeStreamReach(int NN, int CountLimit) {
         bis[i] = cmove->getChannelWidth();
         ais[i] = cmove->getFlowEdg()->getLength();
         rifis[i] = cmove->getRoughness();
-        //ASM 2/9/2017
+        // Compute the maximum volumetric loss rate for this link via Darcy's law:
+        //   NodeLoss = K_sat * wetted_area = K_sat * width * length  [m3/s]
+        // CHANNELCONDUCTIVITY must be supplied in m/s.
         if (percolationOption == 1) {
-            //setCoeffstest(cmove);
-            //poro = soilPtr->getSoilProp(9);  // Surface hydraulic conductivity
-            NodeLoss[i] = bis[i] * ais[i] * ChannelConduc * channelPorosity; // ASM testporo; w*l*poro*ksat [m3/s]
-            ChanLength += ais[i]; // ASM
+            // Constant-conductivity loss: K_sat is fixed for the entire simulation.
+            NodeLoss[i] = bis[i] * ais[i] * ChannelConduc;
+            ChanLength += ais[i];
         } else if (percolationOption == 2) {
-            // Need to get time information here
+            // Transient-conductivity loss: use TransientConduc during the initial wetting
+            // period (Count < CountLimit timesteps with active percolation), then switch
+            // to the lower steady-state ChannelConduc once the bed is saturated.
             if (Count > CountLimit - 1) {
-                NodeLoss[i] = bis[i] * ais[i] * ChannelConduc * channelPorosity;
+                NodeLoss[i] = bis[i] * ais[i] * ChannelConduc;
                 ChanLength += ais[i];
             } else {
-                NodeLoss[i] = bis[i] * ais[i] * TransientConduc * channelPorosity;
+                NodeLoss[i] = bis[i] * ais[i] * TransientConduc;
                 ChanLength += ais[i];
             }
         }
-        //end ASM edits
 
         Slope = cmove->getFlowEdg()->getSlope();
 
@@ -1309,14 +1336,27 @@ void tKinemat::AssignLateralInflux() {
                 cmove->setFt(0.0);
                 //}
                 Preach += clis[i];
-            } else if (percolationOption == 1 || percolationOption == 2) {    //ASM constant loss and transient methods
-                reis1 = reis[i] - NodeLoss[i];
-                if (reis1 < 0) {
-                    clis[i] = reis[i];
-                    reis[i] = 0.0;
-                } else {
+            } else if (percolationOption == 1 || percolationOption == 2) {
+                // Apply bed infiltration loss to this interior link.
+                // When water is present (his[i] > 0), the full NodeLoss is applied
+                // even if it exceeds the lateral inflow. reis[i] is allowed to go
+                // negative, which the kinematic wave solver correctly interprets as
+                // a net sink withdrawing water from in-channel flow.
+                // When the channel is dry, loss is capped at available lateral inflow.
+                if (his[i] > 0.0) {
                     clis[i] = NodeLoss[i];
-                    reis[i] = reis1;
+                    reis[i] -= NodeLoss[i];
+                } else if (reis[i] > NodeLoss[i]) {
+                    clis[i] = NodeLoss[i];
+                    reis[i] -= NodeLoss[i];
+                } else {
+                    // Guard because reis[i] should theoretically never be negative at this point in the code
+                    if (reis[i] > 0.0) {
+                        clis[i] = reis[i];
+                    } else {
+                        clis[i] = 0.0;
+                    }
+                    reis[i] = 0.0;
                 }
                 Preach += clis[i]; // ASM 2/16/2017 this sums percolation in the channel
             }
@@ -1378,17 +1418,22 @@ void tKinemat::AssignLateralInflux() {
                 //}
                 Preach += clis[i];
             } else if (percolationOption == 1 || percolationOption == 2) {
-                if (reis[i] > 0) {
-                    reis1 = reis[i] - NodeLoss[i];
-                    if (reis1 < 0) {
+                // Same logic as interior links above applied to the last link in reach.
+                if (his[i] > 0.0) {
+                    clis[i] = NodeLoss[i];
+                    reis[i] -= NodeLoss[i];
+                } else if (reis[i] > NodeLoss[i]) {
+                    clis[i] = NodeLoss[i];
+                    reis[i] -= NodeLoss[i];
+                } else {
+                    // Guard because reis[i] should theoretically never be negative at this point in the code
+                    if (reis[i] > 0.0) {
                         clis[i] = reis[i];
-                        reis[i] = 0.0;
                     } else {
-                        clis[i] = NodeLoss[i];
-                        reis[i] = reis1;
+                        clis[i] = 0.0;
                     }
-                } else
-                    clis[i] = 0.0;
+                    reis[i] = 0.0;
+                }
                 Preach += clis[i]; // ASM 2/16/2017 this sums percolation in the channel reach
             } //end ASM
         }

--- a/src/tFlowNet/tKinemat.cpp
+++ b/src/tFlowNet/tKinemat.cpp
@@ -63,16 +63,17 @@ tKinemat::tKinemat(SimulationControl *sPtr, tMesh<tCNode> *gridRef, tInputFile &
     kincoef = infile.ReadItem(kincoef, "KINEMVELCOEF");
     Roughness = infile.ReadItem(Roughness, "CHANNELROUGHNESS");
 
-    percolationOption = infile.ReadItem(percolationOption, "OPTPERCOLATION"); // ASM 2/9/2017
-    if(percolationOption==1) { //TODO WR 10062023 should not need if statement but currently CHANPOREINDEX fails assert in read function
-        ChannelConduc = infile.ReadItem(ChannelConduc, "CHANNELCONDUCTIVITY"); // ASM
-        TransientConduc = infile.ReadItem(TransientConduc, "TRANSIENTCONDUCTIVITY"); //ASM
-        TransientTime = infile.ReadItem(TransientTime, "TRANSIENTTIME"); //ASM
-        channelPorosity = infile.ReadItem(channelPorosity, "CHANNELPOROSITY"); // ASM
-        ChanWidth = infile.ReadItem(ChanWidth, "CHANNELWIDTH"); //ASM temporary fix
-        PoreInd = infile.ReadItem(PoreInd, "CHANPOREINDEX");//ASM
-        PsiB = infile.ReadItem(PsiB, "CHANPSIB");//ASM
-        //PsiB = PsiB/1000.; //ASM convert to m
+    percolationOption = infile.ReadItem(percolationOption, "OPTPERCOLATION");
+    if (percolationOption != 0) {
+        ChannelConduc = infile.ReadItem(ChannelConduc, "CHANNELCONDUCTIVITY");
+        channelPorosity = infile.ReadItem(channelPorosity, "CHANNELPOROSITY");
+        if (percolationOption == 2) {
+            TransientConduc = infile.ReadItem(TransientConduc, "TRANSIENTCONDUCTIVITY");
+            TransientTime = infile.ReadItem(TransientTime, "TRANSIENTTIME");
+        } else if (percolationOption == 3) {
+            PoreInd = infile.ReadItem(PoreInd, "CHANPOREINDEX");
+            PsiB = infile.ReadItem(PsiB, "CHANPSIB");
+        }
     }
     IntStormMax = infile.ReadItem(IntStormMax, "INTSTORMMAX"); //ASM
 

--- a/src/tFlowNet/tKinemat.h
+++ b/src/tFlowNet/tKinemat.h
@@ -172,7 +172,7 @@ protected:
 
 /*** Start edits by JECR 2015 ***/
   int optres, checkID, checkNode;
-  double  ChannelConduc, ReachLoss, poro, reis1, Pchannel, Preach, ChanWidth, TotWidth, ChanLength, channelPorosity; //ASM
+  double  ChannelConduc, ReachLoss, poro, reis1, Pchannel, Preach, TotWidth, ChanLength, channelPorosity; //ASM
   double  TransientConduc, TransientTime, TotChanLength; //ASM
   double  ExtraPerc, PotentialPerc, TotalPerc, Qin1; //ASM 2/14/2017 Variables for calculating channel loss
   int percolationOption, CountLimit, Count; //ASM perolcation option


### PR DESCRIPTION
This pull request fixes several bugs in the channel transmission loss module that resulted in near-zero losses regardless of parameter values, targeting the upcoming v6.0.0 release.

When `OPTPERCOLATION` was set to 1 or 2, transmission losses were effectively negligible in the tested scenarios. The module was activated and parameters were read correctly, but losses were applied only to lateral hillslope inflow arriving at the channel in the current timestep. Water already flowing in the channel from upstream reaches was never reduced.

The root cause was that the loss subtraction was floored at zero, preventing the lateral inflow term (`reis`) from going negative. In the kinematic wave continuity equation, `reis` is the source/sink term. Allowing it to go negative is the correct way to represent a net withdrawal from in-channel flow. A separate bug further reduced losses by multiplying the maximum loss flux formula by `CHANNELPOROSITY` which does not match the equations in [Schreiner-McGraw & Vivoni (2018)](https://doi.org/10.1029/2018WR022842). Code comments hinted at this being added for testing but was not removed.

There are remaining enhancements for `OPTPERCOLATION = 2` to be addressed in future releases. The transient time count checking uses a value left over from the last reach processed in the previous time step. So for a watershed with multiple reaches, the counter is being driven by whichever reach happens to be last in the iteration order. Additionally, the count variable is a single class-level variable shared across all reaches, so every reach flips from transient to steady-state at the same time, even though upstream headwater reaches would realistically saturate before large downstream reaches. 

**Technical Changes (C++ / Inputs)**
* tKinemat.cpp: In `InitializeStreamReach()`, removed `channelPorosity` from the `NodeLoss` formula for options 1 and 2. The volumetric loss rate is `K_sat × width × length` with no porosity factor.
* tKinemat.cpp: In `AssignLateralInflux()`, replaced the floor at zero loss logic for options 1 and 2 with a three-branch check: when the channel holds water (`his[i] > 0`), the full NodeLoss is applied and `reis[i]` is allowed to go negative, representing a net sink on in-channel flow. When the channel is dry, loss is capped at available lateral inflow.
* tKinemat.cpp: In `RunRoutingModel()`, added a post-solver depth clamp (`his[i] = max(0, his[i])`) to prevent negative depths from causing `NaN` in Manning's calculation.
* tKinemat.cpp: `CHANNELCONDUCTIVITY` and `TRANSIENTCONDUCTIVITY` are now converted from mm/hr to m/s immediately after being read. Previously the formula required m/s but no conversion was applied, making the effective input unit inconsistent with all other hydraulic conductivity parameters in tRIBS which use mm/hr.
* tKinemat.cpp: `OPTPERCOLATION = 3` (Green-Ampt) now exits with an error message at startup. This option has multiple unresolved bugs (stale node pointer, infiltration front never accumulated, wrong area used for loss calculation) that cause it to silently produce incorrect results. Options 1 and 2 remain available.
* tKinemat.cpp: Reworked what parameter inputs must be provided by the user based on the `OPTPERCOLATION` option selected. Previously users had to specify values for all parameter whether the option selected use them or not.

**Input Flags**

* CHANNELCONDUCTIVITY: now expected in mm/hr (previously required m/s).
* TRANSIENTCONDUCTIVITY: same unit change as above.
* OPTPERCOLATION = 3: no longer accepted; simulation will exit with an error message directing users to options 1 or 2. To be re-enabled in future versions.