### PR TITLE
refactor: Standardize output file formats to CSV

### DIFF
--- a/src/tFlowNet/tFlowResults.cpp
+++ b/src/tFlowNet/tFlowResults.cpp
@@ -481,22 +481,15 @@ void tFlowResults::writeAndUpdate( double time, int forenum )
 **
 ***************************************************************************/
 void tFlowResults::write_inter_hyd(char *filename, char *identification,
-								   int foreNum) 
-{ 
-	FILE *ifile;
+								   int foreNum)
+{
 	int ii;              //Loop counter 
-	int it_hour,it_min;  //Hours and minutes to print results 
-	
-	if ((ifile=fopen(filename,"w")) == nullptr) {
-		cout<<"\nError: Unable to open *.mrf file: "<<filename<<endl;
-		cout<<"Exiting Program..."<<endl;
-		exit(2);
-	}
-	
+	int it_hour, it_min;  //Hours and minutes to print results 
+
 	// Assign Forecast State if Option != 0
 	if (timer->getoptForecast()!=0)
 		fState[count] = checkForecast();
-		
+
 #ifdef PARALLEL_TRIBS
 
    // Variables for sums, mins, and maxs
@@ -538,66 +531,131 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
    pSca = tParallel::sum(sca, iimax);
    pPerc = tParallel::sum(Perc, iimax); //ASM percolation option
    pQunsat = tParallel::sum(qunsat, iimax);
-   
+
    // Master processor writes file
    if (tParallel::isMaster()) {
 #endif
 
-		// Print out header information
-			// fprintf(ifile,"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			// SKY2008Snow from AJR2007
-			fprintf(ifile,"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		ofstream ifile(filename);
+		if (!ifile.is_open()) {
+			cout<<"\nError: Unable to open *.mrf file: "<<filename<<endl;
+			cout<<"Exiting Program..."<<endl;
+			exit(2);
+		}
+		ifile << fixed << setprecision(3);
 
-					"Time", "Srf","MAP","RainMax", "RainMin","FState", "MSM100", "MSMRt", 
-					// "MSMU", "MGW","MET", "%Sat", "%Rain");
-					// SKY2008Snow from AJR2007
-					"MSMU", "MDGW","MET", "SatPercent", "RainPercent",
-					"AvSWE" , "AvMelt" , "AvSnSub" , "AvSnEvap" , "AvSTC" , "AvDUInt" , "AvSLHF" , "AvSSHF" , "AvSPHF" , "AvSGHF" , //added by AJR 2007 @ NMT // Added "AvSnSub" , "AvSnEvap" CJC2020
-					"AvSRLI" , "AvSRLO" , "AvSRSI" , "AvInSn" , "AvInSu" , "AvInUn" , "SCA", "ChannelPercolation", "Qunsat");//added by AJR 2007 @ NMT
-			fprintf(ifile,"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					"hr" , "m3/s" , "mm/hr" , "mm/hr" , "mm/hr" , "[]" , "[]" , "[]" , "[]" , "mm" , 
-	    				"mm" , "[]" , "[]" , "cm" , "cm" , "cm" , "cm" , "C" , "kJ/m2" , "kJ/m2" , "kJ/m2" , //added by AJR 2007 @ NMT // added "cm" , "cm" CJC2020
-	    				"kJ/m2" , "kJ/m2" , "kJ/m2" , "kJ/m2" , "kJ/m2" , "cm" , "cm" , "cm", "[]", "m3", "mm/hr" );//added by AJR 2007 @ NMT // removed extra header for kJ/m2 CJC2020 //akram: Need to confirm unit for Percolation
+		// Write header
+		ifile << "Time_hr,"          // 1
+		      << "Srf_m3_s,"         // 2
+		      << "MAP_mm_hr,"        // 3
+		      << "RainMax_mm_hr,"    // 4
+		      << "RainMin_mm_hr,"    // 5
+		      << "FState_[],"        // 6
+		      << "MSM100_[],"        // 7
+		      << "MSMRt_[],"         // 8
+		      << "MSMU_[],"          // 9
+		      << "MDGW_mm,"          // 10
+		      << "MET_mm,"           // 11
+		      << "SatPercent_[],"    // 12
+		      << "RainPercent_[],"   // 13
+		      << "AvSWE_cm,"         // 14
+		      << "AvMelt_cm,"        // 15
+		      << "AvSnSub_cm,"       // 16
+		      << "AvSnEvap_cm,"      // 17
+		      << "AvSTC_C,"          // 18
+		      << "AvDUInt_kJ_m2,"    // 19
+		      << "AvSLHF_kJ_m2,"     // 20
+		      << "AvSSHF_kJ_m2,"     // 21
+		      << "AvSPHF_kJ_m2,"     // 22
+		      << "AvSGHF_kJ_m2,"     // 23
+		      << "AvSRLI_kJ_m2,"     // 24
+		      << "AvSRLO_kJ_m2,"     // 25
+		      << "AvSRSI_kJ_m2,"     // 26
+		      << "AvInSn_cm,"        // 27
+		      << "AvInSu_cm,"        // 28
+		      << "AvInUn_cm,"        // 29
+		      << "SCA_[],"           // 30
+		      << "ChannelPerc_m3,"   // 31
+		      << "Qunsat_mm_hr\n";   // 32
+		writeFlag = 1;
 
-			// fprintf(ifile,"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			//		"hr","m3/s","mm/hr","mm/hr","mm/hr","[]", "[]", "[]", "[]",
-			//		"mm","mm", "[]", "[]");
-			writeFlag = 1;
-		
-		for (ii=0; ii < iimax; ii++) {    
+		for (ii=0; ii < iimax; ii++) {
 			timer->res_time_begin(ii+1, &it_hour, &it_min);
-			//fprintf(ifile,"%d.%d\t%f\t%f\t%f\t%f\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n",
+			double time_hr = it_hour + it_min/60.0;
 
 #ifdef PARALLEL_TRIBS
-
-         // Print min, max, and summ variables from all processors
-         fprintf(ifile,"%d.%d\t%f\t%f\t%f\t%f\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n",
-               it_hour, it_min, pPhydro[ii]+pMhydro[ii], pCrr[ii],
-               pMax[ii], pMin[ii], fState[ii], pMsm[ii], pMsmRt[ii],pMsmU[ii], 
-               pMgw[ii], pMet[ii], pSat[ii], pFrac[ii],
-               pSwe[ii], pMelt[ii], pSnSub[ii], pSnEvap[ii], pStC[ii], pDUint[ii], pSlhf[ii], pSshf[ii], // Added pSnSub[ii], pSnEvap[ii] CJC2020
-               pSphf[ii], pSghf[ii], pSrli[ii], pSrlo[ii], pSrsi[ii], pIntsn[ii],
-               pIntsub[ii], pIntunl[ii], pSca[ii], pPerc[ii], pQunsat[ii]);
-
+			ifile << time_hr                      << ","  // 1  Time_hr
+			      << pPhydro[ii]+pMhydro[ii]      << ","  // 2  Srf_m3_s
+			      << pCrr[ii]                     << ","  // 3  MAP_mm_hr
+			      << pMax[ii]                     << ","  // 4  RainMax_mm_hr
+			      << pMin[ii]                     << ","  // 5  RainMin_mm_hr
+			      << fState[ii]                   << ","  // 6  FState_[]
+			      << pMsm[ii]                     << ","  // 7  MSM100_[]
+			      << pMsmRt[ii]                   << ","  // 8  MSMRt_[]
+			      << pMsmU[ii]                    << ","  // 9  MSMU_[]
+			      << pMgw[ii]                     << ","  // 10 MDGW_mm
+			      << pMet[ii]                     << ","  // 11 MET_mm
+			      << pSat[ii]                     << ","  // 12 SatPercent_[]
+			      << pFrac[ii]                    << ","  // 13 RainPercent_[]
+			      << pSwe[ii]                     << ","  // 14 AvSWE_cm
+			      << pMelt[ii]                    << ","  // 15 AvMelt_cm
+			      << pSnSub[ii]                   << ","  // 16 AvSnSub_cm
+			      << pSnEvap[ii]                  << ","  // 17 AvSnEvap_cm
+			      << pStC[ii]                     << ","  // 18 AvSTC_C
+			      << pDUint[ii]                   << ","  // 19 AvDUInt_kJ_m2
+			      << pSlhf[ii]                    << ","  // 20 AvSLHF_kJ_m2
+			      << pSshf[ii]                    << ","  // 21 AvSSHF_kJ_m2
+			      << pSphf[ii]                    << ","  // 22 AvSPHF_kJ_m2
+			      << pSghf[ii]                    << ","  // 23 AvSGHF_kJ_m2
+			      << pSrli[ii]                    << ","  // 24 AvSRLI_kJ_m2
+			      << pSrlo[ii]                    << ","  // 25 AvSRLO_kJ_m2
+			      << pSrsi[ii]                    << ","  // 26 AvSRSI_kJ_m2
+			      << pIntsn[ii]                   << ","  // 27 AvInSn_cm
+			      << pIntsub[ii]                  << ","  // 28 AvInSu_cm
+			      << pIntunl[ii]                  << ","  // 29 AvInUn_cm
+			      << pSca[ii]                     << ","  // 30 SCA_[]
+			      << pPerc[ii]                    << ","  // 31 ChannelPerc_m3
+			      << pQunsat[ii]                  << "\n"; // 32 Qunsat_mm_hr
 #else
-			// SKY2008Snow from AJR2007
-			fprintf(ifile,"%d.%d\t%f\t%f\t%f\t%f\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n",
-					it_hour, it_min, phydro[ii]+mhydro[ii], crr[ii], 
-					max[ii], min[ii], fState[ii], msm[ii], msmRt[ii],msmU[ii], mgw[ii], met[ii], sat[ii], frac[ii],
-					swe[ii], melt[ii], snsub[ii], snevap[ii], stC[ii], DUint[ii], slhf[ii], sshf[ii], sphf[ii], sghf[ii],//added by AJR 2007 @ NMT // Added snsub[ii], snevap[ii] CJC2020
-					srli[ii], srlo[ii], srsi[ii], intsn[ii], intsub[ii], intunl[ii], sca[ii], Perc[ii], qunsat[ii]);//added by AJR 2007 @ NMT
-
-
-					//it_hour, it_min, phydro[ii]+mhydro[ii], crr[ii], 
-					//max[ii], min[ii], fState[ii], msm[ii], msmRt[ii],
-					//msmU[ii], mgw[ii], met[ii], sat[ii], frac[ii]);
+			ifile << time_hr                      << ","  // 1  Time_hr
+			      << phydro[ii]+mhydro[ii]        << ","  // 2  Srf_m3_s
+			      << crr[ii]                      << ","  // 3  MAP_mm_hr
+			      << max[ii]                      << ","  // 4  RainMax_mm_hr
+			      << min[ii]                      << ","  // 5  RainMin_mm_hr
+			      << fState[ii]                   << ","  // 6  FState_[]
+			      << msm[ii]                      << ","  // 7  MSM100_[]
+			      << msmRt[ii]                    << ","  // 8  MSMRt_[]
+			      << msmU[ii]                     << ","  // 9  MSMU_[]
+			      << mgw[ii]                      << ","  // 10 MDGW_mm
+			      << met[ii]                      << ","  // 11 MET_mm
+			      << sat[ii]                      << ","  // 12 SatPercent_[]
+			      << frac[ii]                     << ","  // 13 RainPercent_[]
+			      << swe[ii]                      << ","  // 14 AvSWE_cm
+			      << melt[ii]                     << ","  // 15 AvMelt_cm
+			      << snsub[ii]                    << ","  // 16 AvSnSub_cm
+			      << snevap[ii]                   << ","  // 17 AvSnEvap_cm
+			      << stC[ii]                      << ","  // 18 AvSTC_C
+			      << DUint[ii]                    << ","  // 19 AvDUInt_kJ_m2
+			      << slhf[ii]                     << ","  // 20 AvSLHF_kJ_m2
+			      << sshf[ii]                     << ","  // 21 AvSSHF_kJ_m2
+			      << sphf[ii]                     << ","  // 22 AvSPHF_kJ_m2
+			      << sghf[ii]                     << ","  // 23 AvSGHF_kJ_m2
+			      << srli[ii]                     << ","  // 24 AvSRLI_kJ_m2
+			      << srlo[ii]                     << ","  // 25 AvSRLO_kJ_m2
+			      << srsi[ii]                     << ","  // 26 AvSRSI_kJ_m2
+			      << intsn[ii]                    << ","  // 27 AvInSn_cm
+			      << intsub[ii]                   << ","  // 28 AvInSu_cm
+			      << intunl[ii]                   << ","  // 29 AvInUn_cm
+			      << sca[ii]                      << ","  // 30 SCA_[]
+			      << Perc[ii]                     << ","  // 31 ChannelPerc_m3
+			      << qunsat[ii]                   << "\n"; // 32 Qunsat_mm_hr
 #endif
 		}
 
 #ifdef PARALLEL_TRIBS
    }
 
-     delete [] pPhydro;
+   delete [] pPhydro;
    delete [] pMhydro;
    delete [] pCrr;
    delete [] pMax;
@@ -611,8 +669,8 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
    delete [] pFrac;
    delete [] pSwe;
    delete [] pMelt;
-   delete [] pSnSub; // CJC2020
-   delete [] pSnEvap; // CJC2020
+   delete [] pSnSub;
+   delete [] pSnEvap;
    delete [] pStC;
    delete [] pDUint;
    delete [] pSlhf;
@@ -626,18 +684,12 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
    delete [] pIntsub;
    delete [] pIntunl;
    delete [] pSca;
-   delete [] pPerc; //ASM percolation option
-   delete [] pQunsat; // CJC2025
+   delete [] pPerc;
+   delete [] pQunsat;
 
 #endif
 
-	Cout<<"\nCreating Hydrograph Output: '"<<filename<<"'"<<endl;
-
-#ifdef PARALLEL_TRIBS
-  // If running parallel, Master closes file
-  if (tParallel::isMaster())
-#endif
-	fclose(ifile);                 
+	Cout<<"\nCreating Hydrograph Output: '"<<filename<<"'"<<endl;                 
 	
 	// Copy current rain hyetograph to previous
 	for (ii=0; ii < limit; ii++)
@@ -695,10 +747,9 @@ void tFlowResults::write_extra_hyd(char *name, char *identification)
 ***************************************************************************/
 void tFlowResults::write_Runoff_Types(char *filename, char *)
 {
-	FILE *ifile;
-	int ii;               
-	int it_hour, it_min;  
-	
+	int ii;
+	int it_hour, it_min;
+
 #ifdef PARALLEL_TRIBS
 
   // Sum hydrographs for each runoff type across processors
@@ -707,7 +758,6 @@ void tFlowResults::write_Runoff_Types(char *filename, char *)
   double* pr = tParallel::sum(PsrfRout, iimax);
   double* satr = tParallel::sum(SatsrfRout, iimax);
 
-
   if (tParallel::isMaster()) {
     for (int i = 0; i < iimax; i++) {
       HsrfRout[i] = hr[i];
@@ -715,7 +765,6 @@ void tFlowResults::write_Runoff_Types(char *filename, char *)
       PsrfRout[i] = pr[i];
       SatsrfRout[i] = satr[i];
     }
-
     delete [] hr;
     delete [] sbr;
     delete [] pr;
@@ -726,31 +775,31 @@ void tFlowResults::write_Runoff_Types(char *filename, char *)
   if (tParallel::isMaster()) {
 #endif
 
-	if ((ifile=fopen(filename,"w")) == NULL) {
+	ofstream ifile(filename);
+	if (!ifile.is_open()) {
 		cout<<"\nError: Unable to open *.rft file: "<<filename<<endl;
 		cout<<"Exiting Program..."<<endl;
 		exit(2);
 	}
-	
-	// Write Header
-	fprintf(ifile,"%s\t","Time");
-	fprintf(ifile,"%s\t","Hsrf");
-	fprintf(ifile,"%s\t","Sbsrf");
-	fprintf(ifile,"%s\t","Psrf");
-	fprintf(ifile,"%s\n","Satsrf");
-	fprintf(ifile,"%s\t%s\t%s\t%s\t%s\n","hr","m3/s","m3/s","m3/s","m3/s");
-	
+	ifile << fixed << setprecision(6);
+
+	// Write header
+	ifile << "Time_hr,"      // 1
+	      << "Hsrf_m3_s,"    // 2
+	      << "Sbsrf_m3_s,"   // 3
+	      << "Psrf_m3_s,"    // 4
+	      << "Satsrf_m3_s\n"; // 5
+
 	// Current Hydrographs
-	for (ii=0; ii<iimax; ii++)  {      // Current
+	for (ii=0; ii<iimax; ii++) {
 		timer->res_time_begin(ii+1, &it_hour, &it_min);
-		fprintf(ifile,"%04d.%02d ", it_hour, it_min);
-		fprintf(ifile,"\t%f\t", HsrfRout[ii]);
-		fprintf(ifile,"%f\t", SbsrfRout[ii]);
-		fprintf(ifile,"%f\t", PsrfRout[ii]);
-		fprintf(ifile,"%f\n", SatsrfRout[ii]);
-	}   
+		ifile << it_hour + it_min/60.0 << ","  // 1 Time_hr
+		      << HsrfRout[ii]          << ","  // 2 Hsrf_m3_s
+		      << SbsrfRout[ii]         << ","  // 3 Sbsrf_m3_s
+		      << PsrfRout[ii]          << ","  // 4 Psrf_m3_s
+		      << SatsrfRout[ii]        << "\n"; // 5 Satsrf_m3_s
+	}
 	Cout<<"Creating Runoff Type Output: '"<<filename<<"'"<<endl;
-	fclose(ifile);   
 
 #ifdef PARALLEL_TRIBS
   }

--- a/src/tFlowNet/tFlowResults.cpp
+++ b/src/tFlowNet/tFlowResults.cpp
@@ -458,26 +458,28 @@ void tFlowResults::writeAndUpdate( double time, int forenum )
 }
 
 /***************************************************************************
-** 
+**
 **  tFlowResults: write_inter_hyd(char *filename, char *identification,
 **                               int foreNum)
 **
-**  Write hydrographs corresponding to measured rain
-** 
+**  Write the mean response file (*.mrf) containing basin-wide state 
+**  variables at each output time step as a CSV. In parallel mode, 
+**  distributed arrays are reduced across processors before the 
+**  master writes the file.
+**
 **  Algorithm:
-**	open hydro file
-**	get maximum range in array
-**	if forecasted rain is active
-**	   write headings for three variables
-**	else
-**	   write headings for two variables
-**	for index in array range:
-**	   write type tag 0
-**         write streamflow corresponding to previous step
-**      for index in array range:
-**	   write type tag 1
-**         write streamflowcorresponding to current step
-**      copy hydro file name as last hydro file
+**      assign forecast state flag if forecast option is active
+**      [parallel] reduce all basin-state arrays across processors
+**                 (sum for fluxes/states, min/max for rainfall)
+**      [parallel] restrict file writing to master processor
+**      write CSV header (variable_unit format, 32 columns)
+**      for each output time step:
+**          write decimal time, outlet streamflow, mean areal
+**          precipitation with spatial min/max, forecast state,
+**          mean soil moisture at multiple depths, mean ET and
+**          groundwater level, saturation and rain coverage fractions,
+**          snow pack states and energy fluxes, snow interception,
+**          snow covered area, channel percolation, and unsaturated flow
 **
 ***************************************************************************/
 void tFlowResults::write_inter_hyd(char *filename, char *identification,
@@ -781,7 +783,7 @@ void tFlowResults::write_Runoff_Types(char *filename, char *)
 		cout<<"Exiting Program..."<<endl;
 		exit(2);
 	}
-	ifile << fixed << setprecision(6);
+	ifile << fixed << setprecision(3);
 
 	// Write header
 	ifile << "Time_hr,"      // 1

--- a/src/tFlowNet/tFlowResults.cpp
+++ b/src/tFlowNet/tFlowResults.cpp
@@ -563,7 +563,7 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
 			      << intunl[ii]                   << ","  // 29 AvInUn_cm
 			      << sca[ii]                      << ","  // 30 SCA_[]
 			      << Perc[ii]                     << ","  // 31 ChannelPerc_m3
-			      << qunsat[ii]                   << "\n"; // 32 Qunsat_mm_hr
+			      << qunsat[ii ]                   << "\n"; // 32 Qunsat_mm_hr
 #endif
 		}
 
@@ -584,8 +584,8 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
    delete [] pFrac;
    delete [] pSwe;
    delete [] pMelt;
-   delete [] pSnSub;
-   delete [] pSnEvap;
+   delete [] pSnSub; // CJC2020
+   delete [] pSnEvap; // CJC2020
    delete [] pStC;
    delete [] pDUint;
    delete [] pSlhf;
@@ -599,8 +599,8 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
    delete [] pIntsub;
    delete [] pIntunl;
    delete [] pSca;
-   delete [] pPerc;
-   delete [] pQunsat;
+   delete [] pPerc; //ASM percolation option
+   delete [] pQunsat; // CJC2020
 
 #endif
 

--- a/src/tFlowNet/tFlowResults.cpp
+++ b/src/tFlowNet/tFlowResults.cpp
@@ -332,94 +332,7 @@ void tFlowResults::free_results()
 //=========================================================================
 
 /***************************************************************************
-** 
-**  tFlowResults: read_prev_hyd(char *filename, int index)
 **
-**  Read hydrographs
-**
-**  Algorithm:
-**    open hydro file
-**    read headings
-**    until end of file:
-**     if type tag is index
-**        read streamflow corresponding to previous step
-**     else
-**        discard data
-**    close file
-**
-***************************************************************************/
-void tFlowResults::read_prev_hyd(char *filename, int index) 
-{ 
-	int j,ii,jl;
-	FILE *ifile;
-	char str[80];
-	float flt1, flt2;
-	
-	if ((ifile=fopen(filename,"r")) == NULL) {  
-		cout<<"\nError: Unable to open *.mrf file: "<<filename<<endl;
-		cout<<"Exiting Program..."<<endl;
-		exit(2);
-	}
-	
-	fscanf(ifile,"%d",&jl);
-	for (j=0;j<jl;j++) { 
-		fscanf(ifile,"%s",str);
-	}
-	
-	ii=0;
-	while (!feof(ifile)) { 
-		fscanf(ifile,"%d",&jl);
-		if (jl==index) { 
-			fscanf(ifile,"%s %f %f",str,&flt1,&flt2);
-			phydro[ii]=(double)flt1;
-			crr[ii]=prr[ii]=(double)flt2;
-			ii++;
-		}
-		else fscanf(ifile,"%s %f %f",str,&flt1,&flt2);
-	}
-	
-	iimax=ii;
-	fclose(ifile);
-	return;
-}
-
-/***************************************************************************
-** 
-**  tFlowResults: add_fore_hyd(filename, index)
-**
-**  Write hydrograph corresponding to forecasted rain
-**
-**  Algorithm:
-**    open hydro file
-**    get maximum range in array
-**    for index in array range:
-**      write streamflow corresponding to current step
-**
-***************************************************************************/
-void tFlowResults::add_fore_hyd(char *filename, int index) 
-{
-	FILE *ifile;
-	int ii;              	// Loop counter 
-	int it_hour,it_min;  	// Hours and minutes to print results
-	
-	if ((ifile=fopen(filename,"a")) == NULL) {
-		cout<<"\nError: Unable to open *.mrf file: "<<filename<<endl;
-		cout<<"Exiting Program..."<<endl;
-		exit(2);
-	}
-	for (ii=0; ii<iimax; ii++) { 
-		timer->res_time_mid(ii, &it_hour, &it_min);
-		fprintf(ifile," %d %d_%d %f %f\n",
-				index+2, it_hour, it_min,
-				phydro[ii]+mhydro[ii],
-				crr[ii]);
-	}
-	fclose(ifile);     
-	return;         
-}
-
-/***************************************************************************
-** 
 **  tFlowResults: writeAndUpdate(inter_hour, dt_rain)
 **
 **  Write basin state variables, output and result hydrographs
@@ -698,44 +611,6 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
 		prr[ii] = crr[ii];
 	
 	count++;
-	return;
-}
-
-/***************************************************************************
-** 
-**  tFlowResults: write_extra_hyd(name, identification)
-**
-**  Write hydrographs for the extra gauge. The extra gauge is used to store
-**  virtual variables for the user interface. Values stored are not neccessarily
-**  hydrographs
-**
-**  Algorithm:
-**     open hydro file
-**     get maximum range in array
-**     write headings for one variable
-**     for index in array range:
-**       write streamflow corresponding to current step
-**
-***************************************************************************/
-void tFlowResults::write_extra_hyd(char *name, char *identification)
-{
-	FILE *ifile;
-	int ii;               // Loop counter 
-	int it_hour, it_min;  // Hours and minutes to print results 
-	
-	if ((ifile=fopen(name,"w")) == NULL) {
-		cout<<"\nError: Unable to open extra hydro file: "<<name<<endl;
-		cout<<"Exiting Program..."<<endl;
-		exit(2);
-	}
-	
-	fprintf(ifile,"  1  \n%s\n", identification);
-	for (ii=0; ii < iimax; ii++) {
-		timer->res_time_mid(ii, &it_hour, &it_min);
-		fprintf(ifile," 0 %04d.%02d %f %f\n",
-				it_hour, it_min, phydro[ii]+mhydro[ii], crr[ii]);
-	}
-	fclose(ifile);   
 	return;
 }
 
@@ -1112,7 +987,10 @@ void tFlowResults::store_maxminrain(double time, double value, int flag)
 /***************************************************************************
 ** 
 **  tFlowResults: store_saturation(double time, double value)
-** TODO is it possible to optimize this part of the code?
+**  TODO is it possible to optimize this part of the code?
+**  dcalc, dres, and init are invariant across all store_saturation calls
+**  in the node loop, could be computed once per time step in tFlowNet::SurfaceFlow()?
+**
 ***************************************************************************/
 void tFlowResults::store_saturation(double time, double value, int flag) 
 {   

--- a/src/tFlowNet/tFlowResults.h
+++ b/src/tFlowNet/tFlowResults.h
@@ -37,6 +37,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <fstream>
+#include <iomanip>
 #include <cstdio>
 
 //=========================================================================

--- a/src/tFlowNet/tFlowResults.h
+++ b/src/tFlowNet/tFlowResults.h
@@ -39,7 +39,6 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
-#include <cstdio>
 
 //=========================================================================
 //
@@ -117,10 +116,7 @@ public:
   void  store_maxminrain(double,double, int);
   void  store_saturation(double,double, int);
   void  free_results();
-  void  read_prev_hyd(char *, int);
-  void  add_fore_hyd(char *, int);
   void  write_inter_hyd(char *, char *, int);
-  void  write_extra_hyd(char *, char *);
   void  write_Runoff_Types(char *, char *);
   void  whenTimeIsOver( double );
   void  store_volume(double, double);          

--- a/src/tFlowNet/tKinemat.cpp
+++ b/src/tFlowNet/tKinemat.cpp
@@ -147,7 +147,7 @@ tKinemat::tKinemat(SimulationControl *sPtr, tMesh<tCNode> *gridRef, tInputFile &
              << "\nExiting Program..." << endl << flush;
         exit(2);
     }
-    theOFStream << "1-Time,hr\t " << "2-Qstrm,m3/s\t" << "3-Hlev,m" << "\n";
+    theOFStream << "Time_hr,Qstrm_m3_s,Hlev_m\n";
 #endif
 
     // Allocate memory for stacks in stream nodes
@@ -573,9 +573,8 @@ void tKinemat::SurfaceFlow() {
     // If running in parallel, only partition with last reach writes
     if (tGraph::hasLastReach())
 #endif
-    // CJC2025: Use stream manipulators for proper floating point formatting
     theOFStream << std::fixed << std::setprecision(4) << currentTime
-                << "\t" << Qout << "\t" << OutletNode->getHlevel() << "\n";
+                << "," << Qout << "," << OutletNode->getHlevel() << "\n";
     return;
 }
 
@@ -2365,7 +2364,7 @@ void tKinemat::openOutletFile(tInputFile &infile)
       exit(2);
     }
 
-    theOFStream<<"1-Time,hr\t "<<"2-Qstrm,m3/s\t"<<"3-Hlev,m"<<"\n";
+    theOFStream << "Time_hr,Qstrm_m3_s,Hlev_m\n";
   }
 
 }

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -279,89 +279,89 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				CreateAndOpenFile( &pixinfo[i], pixelnode );
 				
 				// Write Header
-				pixinfo[i]<<"NodeID "//1
-				<<"Time_hr " //2
-				<<"Nwt_mm " //3
-				<<"Nf_mm " //4
-				<<"Nt_mm " //5
-				<<"Mu_mm " //6
-				<<"Mi_mm " //7
-				<<"QpOut_mm_h " //8
-				<<"QpIn_mm_h " //9
-				<<"Trnsm_m2_h " //10
-				<<"GWflx_m3_h " //11
-				<<"Srf_mm " //12
-				<<"Rain_mm_h " //13
-				<<"SoilMoist_[] " //14
-				<<"RootMoist_[] "  //15
-				<<"AirT_oC " //16
-				<<"DewT_oC " //17
-				<<"SurfT_oC " //18
-				<<"SoilT_oC " //19
-				<<"Press_Pa " //20
-				<<"RelHum_[] " //21
-				<<"SkyCov_[] "  //22
-				<<"Wind_m_s " //23
-				<<"NetRad_W_m2 " //24
-				<<"ShrtRadIn_W_m2 " //25
-				<<"ShortRadInSlope_W_m2 "    //25.5  JB2025 @ ASU
-				<<"ShrtRadIn_dir_W_m2 " //27
-				<<"ShrtRadIn_dif_W_m2 " //28
-				<<"ShortAbsbVeg_W_m2 " //29
-				<<"ShortAbsbSoi_W_m2 " //30
-				<<"LngRadIn_W_m2 " //31
-				<<"LngRadOut_W_m2A " //32
-				<<"PotEvp_mm_h " //33
-				<<"ActEvp_mm_h " //34
-				<<"EvpTtrs_mm_h " //35
-				<<"EvpWetCan_mm_h " //36
-				<<"EvpDryCan_mm_h " //37
-				<<"EvpSoil_mm_h " //38
-				<<"Gflux_W_m2 " //39
-				<<"HFlux_W_m2 " //40
-				<<"Lflux_W_m2 " //41
-				<<"NetPrecip_mm_hr " //42
-				<<"LiqWE_cm " //43
-				<<"IceWE_cm "	//44
-				<<"SnWE_cm "	//45
-				<<"SnSub_cm "	//46
-				<<"SnEvap_cm "	//47
-				<<"U_kJ_m2 "  //48
-				<<"RouteWE_cm " //49
-				<<"SnTemp_C "	//50
-				<<"SurfAge_h "	//51
-				<<"SnDepth_cm "	//52
-				<<"SnDensity_kg_m3 "	//53
-				<<"DU_kJ_m2_etistep " //54
-				<<"snLHF_kJ_m2_etistep " //55
-				<<"snSHF_kJ_m2_etistep " //56
-				<<"snGHF_kJ_m2_etistep " //57
-				<<"snPHF_kJ_m2_etistep " //58
-				<<"snRLout_kJ_m2_etistep " //59
-				<<"snRLin_kJ_m2_etistep " //60
-				<<"snRSin_kJ_m2_etistep " //61
-				<<"Uerror_kJ_m2_etistep " //62
-				<<"IntSWEq_cm "		 //63
-				<<"IntSub_cm "		 //64
-				<<"IntSnUnload_cm "	 //65
-				<<"CanStorage_mm " //66
-				<<"CumIntercept_mm " //67
-				<<"Interception_mm " //68
-				<<"Recharge_mm/hr " //69
-				<<"RunOn_mm " //70
-				<<"Srf_Hour_mm " //71
-				<<"Qstrm_m3_s " //72
-				<<"Hlevel_m " //73
-				<<"ThroughFall_[] " //74
-				<<"CanFieldCap_mm " //75
-				<<"DrainCoeff_mm_hr " //76
-				<<"DrainExpPar_1_mm " //77
-				<<"LandUseAlb_[] " //78
-				<<"VegHeight_m " //79
-				<<"OptTransmCoeff_[] " //80
-				<<"StomRes_s_m " //81
-				<<"VegFraction[] " //82
-				<<"LeafAI_[] " //83
+				pixinfo[i]<<"NodeID,"//1
+				<<"Time_hr," //2
+				<<"Nwt_mm," //3
+				<<"Nf_mm," //4
+				<<"Nt_mm," //5
+				<<"Mu_mm," //6
+				<<"Mi_mm," //7
+				<<"QpOut_mm_h," //8
+				<<"QpIn_mm_h," //9
+				<<"Trnsm_m2_h," //10
+				<<"GWflx_m3_h," //11
+				<<"Srf_mm," //12
+				<<"Rain_mm_h," //13
+				<<"SoilMoist_[]," //14
+				<<"RootMoist_[],"  //15
+				<<"AirT_oC," //16
+				<<"DewT_oC," //17
+				<<"SurfT_oC," //18
+				<<"SoilT_oC," //19
+				<<"Press_Pa," //20
+				<<"RelHum_[]," //21
+				<<"SkyCov_[],"  //22
+				<<"Wind_m_s," //23
+				<<"NetRad_W_m2," //24
+				<<"ShrtRadIn_W_m2," //25
+				<<"ShortRadInSlope_W_m2,"    //25.5  JB2025 @ ASU
+				<<"ShrtRadIn_dir_W_m2," //27
+				<<"ShrtRadIn_dif_W_m2," //28
+				<<"ShortAbsbVeg_W_m2," //29
+				<<"ShortAbsbSoi_W_m2," //30
+				<<"LngRadIn_W_m2," //31
+				<<"LngRadOut_W_m2A," //32
+				<<"PotEvp_mm_h," //33
+				<<"ActEvp_mm_h," //34
+				<<"EvpTtrs_mm_h," //35
+				<<"EvpWetCan_mm_h," //36
+				<<"EvpDryCan_mm_h," //37
+				<<"EvpSoil_mm_h," //38
+				<<"Gflux_W_m2," //39
+				<<"HFlux_W_m2," //40
+				<<"Lflux_W_m2," //41
+				<<"NetPrecip_mm_hr," //42
+				<<"LiqWE_cm," //43
+				<<"IceWE_cm,"	//44
+				<<"SnWE_cm,"	//45
+				<<"SnSub_cm,"	//46
+				<<"SnEvap_cm,"	//47
+				<<"U_kJ_m2,"  //48
+				<<"RouteWE_cm," //49
+				<<"SnTemp_C,"	//50
+				<<"SurfAge_h,"	//51
+				<<"SnDepth_cm,"	//52
+				<<"SnDensity_kg_m3,"	//53
+				<<"DU_kJ_m2_etistep," //54
+				<<"snLHF_kJ_m2_etistep," //55
+				<<"snSHF_kJ_m2_etistep," //56
+				<<"snGHF_kJ_m2_etistep," //57
+				<<"snPHF_kJ_m2_etistep," //58
+				<<"snRLout_kJ_m2_etistep," //59
+				<<"snRLin_kJ_m2_etistep," //60
+				<<"snRSin_kJ_m2_etistep," //61
+				<<"Uerror_kJ_m2_etistep," //62
+				<<"IntSWEq_cm,"		 //63
+				<<"IntSub_cm,"		 //64
+				<<"IntSnUnload_cm,"	 //65
+				<<"CanStorage_mm," //66
+				<<"CumIntercept_mm," //67
+				<<"Interception_mm," //68
+				<<"Recharge_mm/hr," //69
+				<<"RunOn_mm," //70
+				<<"Srf_Hour_mm," //71
+				<<"Qstrm_m3_s," //72
+				<<"Hlevel_m," //73
+				<<"ThroughFall_[]," //74
+				<<"CanFieldCap_mm," //75
+				<<"DrainCoeff_mm_hr," //76
+				<<"DrainExpPar_1_mm," //77
+				<<"LandUseAlb_[]," //78
+				<<"VegHeight_m," //79
+				<<"OptTransmCoeff_[]," //80
+				<<"StomRes_s_m," //81
+				<<"VegFraction[]," //82
+				<<"LeafAI_[]" //83
 				<<"\n";
 				
 				pixinfo[i].setf( ios::right, ios::adjustfield );
@@ -961,115 +961,112 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 					if (cos_slope < 1E-9) cos_slope = 1.E-9; 
 				}
 				
-				this->pixinfo[i]<<setw(8)<<this->nodeList[i]
-				<<setw(13)<<extension<<" "
-				/* 3 */   <<setw(10)<<(this->uzel[i]->getNwtNew() / cos_slope)<<" "
-				
-				<<setprecision(7)
-				<<setw(6)<<this->uzel[i]->getNfNew() / cos_slope<<" "
-				/* 5 */	  <<setw(6)<<this->uzel[i]->getNtNew() / cos_slope<<" "
-				
-				<<setprecision(7)
-				<<setw(7)<<this->uzel[i]->getMuNew() / cos_slope<<" "
-				<<setw(7)<<this->uzel[i]->getMiNew() / cos_slope<<"   "
-				
-				<<setprecision(7)
-				<<setw(10)<<this->uzel[i]->getQpout()*1.E-6/this->uzel[i]->getVArea()<<"  "
-				<<setw(10)<<this->uzel[i]->getQpin() *1.E-6/this->uzel[i]->getVArea()<<"   "   
-				/* 10 */  <<setw(10)<<this->uzel[i]->getTransmiss()*1.E-6<<"    "
-				<<setw(10)<<this->uzel[i]->getGwaterChng()*1.E-9<<"  "
-				
-				<<setprecision(7)
-				<<setw(8) <<this->uzel[i]->getSrf()<<"  "//WR debug 02062024, this is a total not a rate--and its reset every loop so every 3.75 minutes in sim time
-				<<setw(10)<<this->uzel[i]->getRain()<<"  "
-				<<setw(10)<<this->uzel[i]->getSoilMoistureSC()<<"  "
-				/* 15 */  <<setw(10)<<this->uzel[i]->getRootMoistureSC()<<" "
-				
-				<<setprecision(7)
-				<<this->uzel[i]->getAirTemp()<<" "
-				<<this->uzel[i]->getDewTemp()<<" "
-				<<this->uzel[i]->getSurfTemp()<<" "
-				<<this->uzel[i]->getSoilTemp()<<" "
-				
-				/* 20 */  <<this->uzel[i]->getAirPressure()<<" "
-				<<this->uzel[i]->getRelHumid()<<" "
-				<<this->uzel[i]->getSkyCover()<<" "
-				<<this->uzel[i]->getWindSpeed()<<" "
-				<<this->uzel[i]->getNetRad()<<" "
-				
-				/* 25 */  <<this->uzel[i]->getShortRadIn()<< " "
-                << this->uzel[i]->getShortRadSlope() << " "  // JB2025 @ ASU
-				<<this->uzel[i]->getShortRadIn_dir()<< " "
-				<<this->uzel[i]->getShortRadIn_dif()<< " "
-				<<this->uzel[i]->getShortAbsbVeg()<< " "
-				/* 30 */ <<this->uzel[i]->getShortAbsbSoi()<< " "
-				
-				<<this->uzel[i]->getLongRadIn()<< " "
-				<<this->uzel[i]->getLongRadOut()<< " "
-				<<this->uzel[i]->getPotEvap()<<" "
-				<<this->uzel[i]->getActEvap()<<" "
-				/* 35 */ <<this->uzel[i]->getEvapoTrans()<<" "
-				
-				<<this->uzel[i]->getEvapWetCanopy()<<" "
-				<<this->uzel[i]->getEvapDryCanopy()<<" "
-				<<this->uzel[i]->getEvapSoil()<<" "
-				<<this->uzel[i]->getGFlux()<<" "
-				/* 40 */ <<this->uzel[i]->getHFlux()<<" "
-				<<this->uzel[i]->getLFlux()<<" "
-				<<this->uzel[i]->getNetPrecipitation()<<" "
+				this->pixinfo[i]<<this->nodeList[i]
+				<<","<<extension
+				/* 3 */   << "," << (this->uzel[i]->getNwtNew() / cos_slope) << ","
 
+				<<setprecision(4)
+				<< this->uzel[i]->getNfNew() / cos_slope << ","
+				/* 5 */   << this->uzel[i]->getNtNew() / cos_slope << ","
+
+				<< this->uzel[i]->getMuNew() / cos_slope << ","
+				<< this->uzel[i]->getMiNew() / cos_slope << ","
+				<< this->uzel[i]->getQpout()*1.E-6/this->uzel[i]->getVArea() << ","
+				<< this->uzel[i]->getQpin() *1.E-6/this->uzel[i]->getVArea() << ","
+				/* 10 */  << this->uzel[i]->getTransmiss()*1.E-6 << ","
+
+				<< this->uzel[i]->getGwaterChng()*1.E-9 << ","
+				<< this->uzel[i]->getSrf() << "," //WR debug 02062024, this is a total not a rate--and its reset every loop so every 3.75 minutes in sim time
+				<< this->uzel[i]->getRain() << ","
+				<< this->uzel[i]->getSoilMoistureSC() << ","
+				/* 15 */  << this->uzel[i]->getRootMoistureSC() << ","
+
+				<< this->uzel[i]->getAirTemp() << ","
+				<< this->uzel[i]->getDewTemp() << ","
+				<< this->uzel[i]->getSurfTemp() << ","
+				<< this->uzel[i]->getSoilTemp() << ","
+				/* 20 */  << this->uzel[i]->getAirPressure() << ","
+
+				<< this->uzel[i]->getRelHumid() << ","
+				<< this->uzel[i]->getSkyCover() << ","
+				<< this->uzel[i]->getWindSpeed() << ","
+				<< this->uzel[i]->getNetRad() << ","
+				/* 25 */  << this->uzel[i]->getShortRadIn() << ","
+
+				<< this->uzel[i]->getShortRadSlope() << "," // JB2025 @ ASU
+				<< this->uzel[i]->getShortRadIn_dir() << ","
+				<< this->uzel[i]->getShortRadIn_dif() << ","
+				<< this->uzel[i]->getShortAbsbVeg() << ","
+				/* 30 */  << this->uzel[i]->getShortAbsbSoi() << ","
+
+				<< this->uzel[i]->getLongRadIn() << ","
+				<< this->uzel[i]->getLongRadOut() << ","
+				<< this->uzel[i]->getPotEvap() << ","
+				<< this->uzel[i]->getActEvap() << ","
+				/* 35 */  << this->uzel[i]->getEvapoTrans() << ","
+
+				<< this->uzel[i]->getEvapWetCanopy() << ","
+				<< this->uzel[i]->getEvapDryCanopy() << ","
+				<< this->uzel[i]->getEvapSoil() << ","
+				<< this->uzel[i]->getGFlux() << ","
+				/* 40 */  << this->uzel[i]->getHFlux() << ","
+
+				<< this->uzel[i]->getLFlux() << ","
+				<< this->uzel[i]->getNetPrecipitation() << ","
 				// SKY2008Snow from AJR2007
-				<<this->uzel[i]->getLiqWE()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getIceWE()<<" "	//added by AJR 2007 @ NMT
-				/* 45 */ <<(this->uzel[i]->getLiqWE()+this->uzel[i]->getIceWE())<<" "    //added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnSub()<<" "	// added by CJC2020
-				<<this->uzel[i]->getSnEvap()<<" "	// added by CJC2020
-				<<this->uzel[i]->getUnode()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getLiqRouted()<<" "	//added by AJR 2007 @ NMT
-				/* 50 */ <<this->uzel[i]->getSnTempC()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getCrustAge()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnDepth()<<" "	// added by CJC2025
-				<<this->uzel[i]->getRhoSn()<<" "	// added by CJC2025
-				<<this->uzel[i]->getDU()<<" "		//added by AJR 2007 @ NMT
-				/* 55 */ <<this->uzel[i]->getSnLHF()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnSHF()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnGHF()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnPHF()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnRLout()<<" "	//added by AJR 2007 @ NMT
-				/* 60 */ <<this->uzel[i]->getSnRLin()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getSnRSin()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getUerror()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getIntSWE()<<" "	//added by AJR 2007 @ NMT
-				<<this->uzel[i]->getIntSub()<<" "	//added by AJR 2007 @ NMT
-				/* 65 */ <<this->uzel[i]->getIntSnUnload()<<" " //added by AJR 2007 @ NMT
-			
-				<<this->uzel[i]->getCanStorage()<<" "
-				<<this->uzel[i]->getCumIntercept()<<" "
-				<<this->uzel[i]->getInterceptLoss()<<" "
-				/* 69 */ <<this->uzel[i]->getRecharge()<<" "
-				<<this->uzel[i]->getRunOn()<<" "
-				<<this->uzel[i]->getSrf_Hr()<<" ";
-				 
+				<< this->uzel[i]->getLiqWE() << ","        //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getIceWE() << ","        //added by AJR 2007 @ NMT
+				/* 45 */  << (this->uzel[i]->getLiqWE()+this->uzel[i]->getIceWE()) << "," //added by AJR 2007 @ NMT
+
+				<< this->uzel[i]->getSnSub() << ","        // added by CJC2020
+				<< this->uzel[i]->getSnEvap() << ","       // added by CJC2020
+				<< this->uzel[i]->getUnode() << ","        //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getLiqRouted() << ","    //added by AJR 2007 @ NMT
+				/* 50 */  << this->uzel[i]->getSnTempC() << ","    //added by AJR 2007 @ NMT
+
+				<< this->uzel[i]->getCrustAge() << ","     //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getSnDepth() << ","      // added by CJC2025
+				<< this->uzel[i]->getRhoSn() << ","        // added by CJC2025
+				<< this->uzel[i]->getDU() << ","           //added by AJR 2007 @ NMT
+				/* 55 */  << this->uzel[i]->getSnLHF() << ","      //added by AJR 2007 @ NMT
+
+				<< this->uzel[i]->getSnSHF() << ","        //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getSnGHF() << ","        //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getSnPHF() << ","        //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getSnRLout() << ","      //added by AJR 2007 @ NMT
+				/* 60 */  << this->uzel[i]->getSnRLin() << ","     //added by AJR 2007 @ NMT
+
+				<< this->uzel[i]->getSnRSin() << ","       //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getUerror() << ","       //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getIntSWE() << ","       //added by AJR 2007 @ NMT
+				<< this->uzel[i]->getIntSub() << ","       //added by AJR 2007 @ NMT
+				/* 65 */  << this->uzel[i]->getIntSnUnload() << "," //added by AJR 2007 @ NMT
+
+				<< this->uzel[i]->getCanStorage() << ","
+				<< this->uzel[i]->getCumIntercept() << ","
+				<< this->uzel[i]->getInterceptLoss() << ","
+				/* 69 */  << this->uzel[i]->getRecharge() << ","
+				<< this->uzel[i]->getRunOn() << ","
+
+				<< this->uzel[i]->getSrf_Hr() << ",";
 				if (this->uzel[i]->getBoundaryFlag() == kStream)
-					this->pixinfo[i]<<setw(10)<<this->uzel[i]->getQstrm()<<" "
-						//<<setw(6)<<this->uzel[i]->getHlevel()<<endl<<flush;
-						<<setw(6)<<this->uzel[i]->getHlevel()<<" ";// SKYnGM2008LU
+					this->pixinfo[i]<<this->uzel[i]->getQstrm() << ","
+					<< this->uzel[i]->getHlevel() << ",";
 				else
-					//this->pixinfo[i]<<"0.0 0.0"<<endl<<flush;
-					this->pixinfo[i]<<"0.0 0.0 "; // SKYnGM2008LU
-				
+					this->pixinfo[i]<<"0.0,0.0,";
+
 				// SKYnGM2008LU
-				this->pixinfo[i]<<setprecision(7)
-				<< this->uzel[i]->getThroughFall()<<" "
-				<< this->uzel[i]->getCanFieldCap()<<" "
-				<< this->uzel[i]->getDrainCoeff()<<" "
-				<< this->uzel[i]->getDrainExpPar()<<" "
-				/* 80 */ << this->uzel[i]->getLandUseAlb()<<" "
-				<< this->uzel[i]->getVegHeight()<<" "
-				<< this->uzel[i]->getOptTransmCoeff()<<" "
-				<< this->uzel[i]->getStomRes()<<" "
-				<< this->uzel[i]->getVegFraction()<<" "
-				<< this->uzel[i]->getLeafAI()<<endl<< flush;
+				this->pixinfo[i]<<setprecision(4)
+				<< this->uzel[i]->getThroughFall() << ","
+				<< this->uzel[i]->getCanFieldCap() << ","
+				<< this->uzel[i]->getDrainCoeff() << ","
+				<< this->uzel[i]->getDrainExpPar() << ","
+				/* 80 */ << this->uzel[i]->getLandUseAlb() << ","
+				<< this->uzel[i]->getVegHeight() << ","
+				<< this->uzel[i]->getOptTransmCoeff() << ","
+				<< this->uzel[i]->getStomRes() << ","
+				<< this->uzel[i]->getVegFraction() << ","
+				<< this->uzel[i]->getLeafAI() << "\n" << flush;
 
 			}
 		}

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -290,7 +290,7 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				<<"QpIn_mm_h,"
 				<<"Trnsm_m2_h,"        //10
 				<<"GWflx_m3_h,"
-				<<"Srf_mm,"
+				<<"Srf_Hour_mm,"
 				<<"Rain_mm_h,"
 				<<"SoilMoist_[],"
 				<<"RootMoist_[],"      //15
@@ -349,19 +349,18 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				<<"Interception_mm,"
 				<<"Recharge_mm/hr,"
 				<<"RunOn_mm,"          //70
-				<<"Srf_Hour_mm,"
 				<<"Qstrm_m3_s,"
 				<<"Hlevel_m,"
 				<<"ThroughFall_[],"
-				<<"CanFieldCap_mm,"    //75
-				<<"DrainCoeff_mm_hr,"
+				<<"CanFieldCap_mm,"
+				<<"DrainCoeff_mm_hr,"  //75
 				<<"DrainExpPar_1_mm,"
 				<<"LandUseAlb_[],"
 				<<"VegHeight_m,"
-				<<"OptTransmCoeff_[]," //80
-				<<"StomRes_s_m,"
+				<<"OptTransmCoeff_[],"
+				<<"StomRes_s_m,"       //80
 				<<"VegFraction[],"
-				<<"LeafAI_[]"          //83
+				<<"LeafAI_[]"          //82
 				<<"\n";
 				
 				pixinfo[i].setf( ios::right, ios::adjustfield );
@@ -976,7 +975,7 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 				/* 10 */  << this->uzel[i]->getTransmiss()*1.E-6 << ","
 
 				<< this->uzel[i]->getGwaterChng()*1.E-9 << ","
-				<< this->uzel[i]->getSrf() << "," //WR debug 02062024, this is a total not a rate--and its reset every loop so every 3.75 minutes in sim time
+				<< this->uzel[i]->getSrf_Hr() << ","
 				<< this->uzel[i]->getRain() << ","
 				<< this->uzel[i]->getSoilMoistureSC() << ","
 				/* 15 */  << this->uzel[i]->getRootMoistureSC() << ","
@@ -1046,9 +1045,8 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 				<< this->uzel[i]->getCumIntercept() << ","
 				<< this->uzel[i]->getInterceptLoss() << ","
 				/* 69 */  << this->uzel[i]->getRecharge() << ","
-				<< this->uzel[i]->getRunOn() << ","
+				<< this->uzel[i]->getRunOn() << ",";
 
-				<< this->uzel[i]->getSrf_Hr() << ",";
 				if (this->uzel[i]->getBoundaryFlag() == kStream)
 					this->pixinfo[i]<<this->uzel[i]->getQstrm() << ","
 					<< this->uzel[i]->getHlevel() << ",";
@@ -1059,12 +1057,12 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 				this->pixinfo[i]<<setprecision(4)
 				<< this->uzel[i]->getThroughFall() << ","
 				<< this->uzel[i]->getCanFieldCap() << ","
-				<< this->uzel[i]->getDrainCoeff() << ","
+				/* 75 */ << this->uzel[i]->getDrainCoeff() << ","
 				<< this->uzel[i]->getDrainExpPar() << ","
-				/* 80 */ << this->uzel[i]->getLandUseAlb() << ","
+				<< this->uzel[i]->getLandUseAlb() << ","
 				<< this->uzel[i]->getVegHeight() << ","
 				<< this->uzel[i]->getOptTransmCoeff() << ","
-				<< this->uzel[i]->getStomRes() << ","
+				/* 80 */ << this->uzel[i]->getStomRes() << ","
 				<< this->uzel[i]->getVegFraction() << ","
 				<< this->uzel[i]->getLeafAI() << "\n" << flush;
 

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -1350,25 +1350,25 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 	cn = ni.FirstP();
 	while (ni.IsActive()) {
 		
-		intofs<<cn->getID()<<','// 1
-        <<cn->getBoundaryFlag()<<',' // 2
-		<<setprecision(4)<<cn->getZ()<<',' // 3
-		<<setprecision(7)<<cn->getVArea()<<',' // 4
-		<<setprecision(7)<<cn->getContrArea()*1.E-6<<',' //5
-		<<setprecision(6)<<cn->getCurvature()<<',' //6
-		<<cn->getFlowEdg()->getLength()<<',' //7
-		<<cn->getFlowEdg()->getSlope()<<',' // 8
-		<<cn->getFlowEdg()->getVEdgLen()<<',' //9
-		<<setprecision(4)<<cn->getAspect()<<',' // 10
-		<<setprecision(7)<<cn->getSheltFact()<<',' // 11
-		<<cn->getLandFact()<<','<<setprecision(4); // 12
+		intofs<<cn->getID()<<','                              //1
+        <<cn->getBoundaryFlag()<<','                          //2
+		<<setprecision(4)<<cn->getZ()<<','                    //3
+		<<setprecision(7)<<cn->getVArea()<<','                //4
+		<<setprecision(7)<<cn->getContrArea()*1.E-6<<','      //5
+		<<setprecision(6)<<cn->getCurvature()<<','            //6
+		<<cn->getFlowEdg()->getLength()<<','                  //7
+		<<cn->getFlowEdg()->getSlope()<<','                   //8
+		<<cn->getFlowEdg()->getVEdgLen()<<','                 //9
+		<<setprecision(4)<<cn->getAspect()<<','               //10
+		<<setprecision(7)<<cn->getSheltFact()<<','            //11
+		<<cn->getLandFact()<<','<<setprecision(4);            //12
 
 
 
 		tmp1 = floor(cn->getAvSoilMoisture())*1.E-4; 
 		tmp2 = (cn->getAvSoilMoisture()-floor(cn->getAvSoilMoisture()))*1.E+1;
-		intofs<<tmp1<<','<< // 13
-        tmp2<<','; //14
+		intofs<<tmp1<<','<<                                   //13
+        tmp2<<',';                                            //14
 		
 		// -----------  seperate runoff mechanism occurrence and rate
 		Occur = (int)((cn->hsrfOccur-floor(cn->hsrfOccur))*1.E+6);
@@ -1382,8 +1382,8 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			avRate = 0.0;
 			prec = 0;
 		}
-		intofs<<setprecision(6)<<Occur<< // 15
-        setprecision(prec)<<','<<avRate<<','; //16
+		intofs<<setprecision(6)<<Occur<<                      //15
+        setprecision(prec)<<','<<avRate<<',';                 //16
 		
 		// -----------
 		Occur = (int)((cn->sbsrfOccur-floor(cn->sbsrfOccur))*1.E+6);
@@ -1397,8 +1397,8 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			avRate = 0.0;
 			prec = 0;
 		}
-		intofs<<setprecision(6)<<Occur<< //17
-        setprecision(prec)<<','<<avRate<<','; // 18
+		intofs<<setprecision(6)<<Occur<<                      //17
+        setprecision(prec)<<','<<avRate<<',';                 //18
 		
 		// -----------
 		Occur = (int)((cn->psrfOccur-floor(cn->psrfOccur))*1.E+6);
@@ -1412,8 +1412,8 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			avRate = 0.0;
 			prec = 0;
 		}
-		intofs<<setprecision(6)<<Occur<< //19
-        setprecision(prec)<<','<<avRate<<','; //20
+		intofs<<setprecision(6)<<Occur<<                      //19
+        setprecision(prec)<<','<<avRate<<',';                 //20
 		
 		// -----------
 		Occur = (int)((cn->satsrfOccur-floor(cn->satsrfOccur))*1.E+6);
@@ -1427,59 +1427,59 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 			avRate = 0.0;
 			prec = 0;
 		}
-		intofs<<setprecision(6)<<Occur<<',' //21
-			<<setprecision(prec)<<avRate<<',' //22
-			<<setprecision(6)<<cn->satOccur<<',' //23
-			<<setprecision(3)<<cn->RechDisch<<',' //24
-			<<setprecision(4)<<cn->getAvET()<<',' //25
-			<<setprecision(4)<<cn->getAvEvapFract()<<',' //26
-            <<setprecision(4)<<cn->getCumTotEvap() <<',' //27
-            <<setprecision(4)<<cn->getCumBarEvap()<<',' //28
-            <<setprecision(7)<<cn->getCumLHF()<<','//29
-			<<setprecision(7)<<cn->getCumMelt()<<','//30
-			<<setprecision(7)<<cn->getCumSHF()<<','//31
-			<<setprecision(7)<<cn->getCumPHF()<<','//32
-			<<setprecision(7)<<cn->getCumRLin()<<','//33
-			<<setprecision(7)<<cn->getCumRLout()<<','//34
-			<<setprecision(7)<<cn->getCumRSin()<<','//35
-			<<setprecision(7)<<cn->getCumGHF()<<','//36
-			<<setprecision(7)<<cn->getCumUerror()<<','//37
-			<<setprecision(7)<<cn->getCumHrsSun()<<','//38
-			<<setprecision(7)<<cn->getCumHrsSnow()<<','//39
-			<<setprecision(7)<<cn->getPersTimeMax()<<',' //40
-			<<setprecision(7)<<cn->getPeakSWE()<<',' //41
-			<<setprecision(7)<<cn->getInitPackTime()<<',' //42
-			<<setprecision(7)<<cn->getPeakPackTime()<<',' //43
-			<<setprecision(7)<<cn->getCumIntSub()<<','//44
-			<<setprecision(7)<<cn->getCumSnSub()<<','//45
-			<<setprecision(7)<<cn->getCumSnEvap()<<','//46
-			<<setprecision(7)<<cn->getCumIntUnl()<<','//47
-			<<setprecision(7)<<cn->getAvThroughFall()<<',' //48
-			<<setprecision(7)<<cn->getAvCanFieldCap()<<',' //49
-			<<setprecision(7)<<cn->getAvDrainCoeff()<<',' //50
-			<<setprecision(7)<<cn->getAvDrainExpPar()<<',' //51
-			<<setprecision(7)<<cn->getAvLandUseAlb()<<',' //52
-			<<setprecision(7)<<cn->getAvVegHeight()<<','  //53
-			<<setprecision(7)<<cn->getAvOptTransmCoeff()<<',' //54
-			<<setprecision(7)<<cn->getAvStomRes()<<',' // 55
-			<<setprecision(7)<<cn->getAvVegFraction()<<',' //56
-			<<setprecision(7)<<cn->getAvLeafAI()<<',' //57
-			<<setprecision(7)<<cn->getAvEvapThresh()<<',' //58
-			<<setprecision(7)<<cn->getAvTransThresh()<<',' //59
-            <<setprecision(7)<<cn->getBedrockDepth()<<',' //60 bedrock depth mm
-           << setprecision(7) << cn->getKs() << ',' // 61
-           << setprecision(7) << cn->getThetaS() << ',' // 62
-           << setprecision(7) << cn->getThetaR() << ',' // 63
-           << setprecision(7) << cn->getPoreSize() << ',' // 64
-           << setprecision(7) << cn->getAirEBubPres() << ',' // 65
-           << setprecision(7) << cn->getDecayF() << ',' // 66
-           << setprecision(7) << cn->getSatAnRatio() << ',' // 67
-           << setprecision(7) << cn->getUnsatAnRatio() << ',' // 68
-           << setprecision(7) << cn->getPorosity() << ',' // 69
-           << setprecision(7) << cn->getVolHeatCond() << ',' // 70
-           << setprecision(7) << cn->getSoilHeatCap() << ',' // 71
-           << setprecision(7) << cn->getSoilID() << ',' //72
-           << setprecision(7) << cn->getLandUse(); // 73
+		intofs<<setprecision(6)<<Occur<<','                   //21
+           << setprecision(prec)<<avRate<<','                 //22
+           << setprecision(6)<<cn->satOccur<<','              //23
+           << setprecision(3)<<cn->RechDisch<<','             //24
+           << setprecision(4)<<cn->getAvET()<<','             //25
+           << setprecision(4)<<cn->getAvEvapFract()<<','      //26
+           << setprecision(4)<<cn->getCumTotEvap() <<','      //27
+           << setprecision(4)<<cn->getCumBarEvap()<<','       //28
+           << setprecision(7)<<cn->getCumLHF()<<','           //29
+           << setprecision(7)<<cn->getCumMelt()<<','          //30
+           << setprecision(7)<<cn->getCumSHF()<<','           //31
+           << setprecision(7)<<cn->getCumPHF()<<','           //32
+           << setprecision(7)<<cn->getCumRLin()<<','          //33
+           << setprecision(7)<<cn->getCumRLout()<<','         //34
+           << setprecision(7)<<cn->getCumRSin()<<','          //35
+           << setprecision(7)<<cn->getCumGHF()<<','           //36
+           << setprecision(7)<<cn->getCumUerror()<<','        //37
+           << setprecision(7)<<cn->getCumHrsSun()<<','        //38
+           << setprecision(7)<<cn->getCumHrsSnow()<<','       //39
+           << setprecision(7)<<cn->getPersTimeMax()<<','      //40
+           << setprecision(7)<<cn->getPeakSWE()<<','          //41
+           << setprecision(7)<<cn->getInitPackTime()<<','     //42
+           << setprecision(7)<<cn->getPeakPackTime()<<','     //43
+           << setprecision(7)<<cn->getCumIntSub()<<','        //44
+           << setprecision(7)<<cn->getCumSnSub()<<','         //45
+           << setprecision(7)<<cn->getCumSnEvap()<<','        //46
+           << setprecision(7)<<cn->getCumIntUnl()<<','        //47
+           << setprecision(7)<<cn->getAvThroughFall()<<','    //48
+           << setprecision(7)<<cn->getAvCanFieldCap()<<','    //49
+           << setprecision(7)<<cn->getAvDrainCoeff()<<','     //50
+           << setprecision(7)<<cn->getAvDrainExpPar()<<','     //51
+           << setprecision(7)<<cn->getAvLandUseAlb()<<','     //52
+           << setprecision(7)<<cn->getAvVegHeight()<<','       //53
+           << setprecision(7)<<cn->getAvOptTransmCoeff()<<',' //54
+           << setprecision(7)<<cn->getAvStomRes()<<','        //55
+           << setprecision(7)<<cn->getAvVegFraction()<<','    //56
+           << setprecision(7)<<cn->getAvLeafAI()<<','         //57
+           << setprecision(7)<<cn->getAvEvapThresh()<<','     //58
+           << setprecision(7)<<cn->getAvTransThresh()<<','    //59
+           << setprecision(7)<<cn->getBedrockDepth()<<','     //60 bedrock depth mm
+           << setprecision(7) << cn->getKs() << ','           //61
+           << setprecision(7) << cn->getThetaS() << ','       //62
+           << setprecision(7) << cn->getThetaR() << ','       //63
+           << setprecision(7) << cn->getPoreSize() << ','     //64
+           << setprecision(7) << cn->getAirEBubPres() << ','  //65
+           << setprecision(7) << cn->getDecayF() << ','       //66
+           << setprecision(7) << cn->getSatAnRatio() << ','   //67
+           << setprecision(7) << cn->getUnsatAnRatio() << ',' //68
+           << setprecision(7) << cn->getPorosity() << ','     //69
+           << setprecision(7) << cn->getVolHeatCond() << ','  //70
+           << setprecision(7) << cn->getSoilHeatCap() << ','  //71
+           << setprecision(7) << cn->getSoilID() << ','       //72
+           << setprecision(7) << cn->getLandUse();            //73
 
         intofs<<"\n";
 		
@@ -1508,9 +1508,9 @@ void tCOutput<tSubNode>::WriteOutletInfo( double time )
 			if ( Outlets[i] && OutletList[i] < this->g->getNodeList()->getActiveSize()) {
 #endif
 				// CJC2025: Use fixed format with 4 decimal places for time
-				outletinfo[i] << std::fixed << std::setprecision(4) << time << "\t"
-				              << setw(10) << Outlets[i]->getQstrm() << "\t"
-				              << setw(6)  << Outlets[i]->getHlevel() << "\n";
+				outletinfo[i] << std::fixed << std::setprecision(4) << time << ","
+				              << Outlets[i]->getQstrm() << ","
+				              << Outlets[i]->getHlevel() << "\n";
 			}
 		}
 	}
@@ -1590,16 +1590,11 @@ void tCOutput<tSubNode>::CreateAndOpenOutlet()
 				
 					if ( !outletinfo[i].good() )
 						cerr<<"File "<<fullName<<"can not be created.";
-					else
-/*SMM
-						Cout<<"Creating Output File: \t '"<<fullName<<"' "<<endl;
-*/
 					
 					// Write Header
-					outletinfo[i]<<"1-Time,hr\t "
-					<<"2-Qstrm,m3/s\t"
-					<<"3-Hlev,m"
-					<<"\n";
+					outletinfo[i] << "Time_hr"  << ","
+					<< "Qstrm_m3/s" << ","
+					<< "Hlev_m"  << "\n";
 				}
 			}
 		}

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -279,89 +279,89 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				CreateAndOpenFile( &pixinfo[i], pixelnode );
 				
 				// Write Header
-				pixinfo[i]<<"NodeID,"//1
-				<<"Time_hr," //2
-				<<"Nwt_mm," //3
-				<<"Nf_mm," //4
-				<<"Nt_mm," //5
-				<<"Mu_mm," //6
-				<<"Mi_mm," //7
-				<<"QpOut_mm_h," //8
-				<<"QpIn_mm_h," //9
-				<<"Trnsm_m2_h," //10
-				<<"GWflx_m3_h," //11
-				<<"Srf_mm," //12
-				<<"Rain_mm_h," //13
-				<<"SoilMoist_[]," //14
-				<<"RootMoist_[],"  //15
-				<<"AirT_oC," //16
-				<<"DewT_oC," //17
-				<<"SurfT_oC," //18
-				<<"SoilT_oC," //19
-				<<"Press_Pa," //20
-				<<"RelHum_[]," //21
-				<<"SkyCov_[],"  //22
-				<<"Wind_m_s," //23
-				<<"NetRad_W_m2," //24
-				<<"ShrtRadIn_W_m2," //25
-				<<"ShortRadInSlope_W_m2,"    //25.5  JB2025 @ ASU
-				<<"ShrtRadIn_dir_W_m2," //27
-				<<"ShrtRadIn_dif_W_m2," //28
-				<<"ShortAbsbVeg_W_m2," //29
+				pixinfo[i]<<"NodeID,"  //1
+				<<"Time_hr,"
+				<<"Nwt_mm,"
+				<<"Nf_mm,"
+				<<"Nt_mm,"             //5
+				<<"Mu_mm,"
+				<<"Mi_mm,"
+				<<"QpOut_mm_h,"
+				<<"QpIn_mm_h,"
+				<<"Trnsm_m2_h,"        //10
+				<<"GWflx_m3_h,"
+				<<"Srf_mm,"
+				<<"Rain_mm_h,"
+				<<"SoilMoist_[],"
+				<<"RootMoist_[],"      //15
+				<<"AirT_oC,"
+				<<"DewT_oC,"
+				<<"SurfT_oC,"
+				<<"SoilT_oC,"
+				<<"Press_Pa,"          //20
+				<<"RelHum_[],"
+				<<"SkyCov_[],"
+				<<"Wind_m_s,"
+				<<"NetRad_W_m2,"
+				<<"ShrtRadIn_W_m2,"    //25
+				<<"ShortRadInSlope_W_m2,"    // JB2025 @ ASU
+				<<"ShrtRadIn_dir_W_m2,"
+				<<"ShrtRadIn_dif_W_m2,"
+				<<"ShortAbsbVeg_W_m2,"
 				<<"ShortAbsbSoi_W_m2," //30
-				<<"LngRadIn_W_m2," //31
-				<<"LngRadOut_W_m2A," //32
-				<<"PotEvp_mm_h," //33
-				<<"ActEvp_mm_h," //34
-				<<"EvpTtrs_mm_h," //35
-				<<"EvpWetCan_mm_h," //36
-				<<"EvpDryCan_mm_h," //37
-				<<"EvpSoil_mm_h," //38
-				<<"Gflux_W_m2," //39
-				<<"HFlux_W_m2," //40
-				<<"Lflux_W_m2," //41
-				<<"NetPrecip_mm_hr," //42
-				<<"LiqWE_cm," //43
-				<<"IceWE_cm,"	//44
-				<<"SnWE_cm,"	//45
-				<<"SnSub_cm,"	//46
-				<<"SnEvap_cm,"	//47
-				<<"U_kJ_m2,"  //48
-				<<"RouteWE_cm," //49
-				<<"SnTemp_C,"	//50
-				<<"SurfAge_h,"	//51
-				<<"SnDepth_cm,"	//52
-				<<"SnDensity_kg_m3,"	//53
-				<<"DU_kJ_m2_etistep," //54
-				<<"snLHF_kJ_m2_etistep," //55
-				<<"snSHF_kJ_m2_etistep," //56
-				<<"snGHF_kJ_m2_etistep," //57
-				<<"snPHF_kJ_m2_etistep," //58
-				<<"snRLout_kJ_m2_etistep," //59
-				<<"snRLin_kJ_m2_etistep," //60
-				<<"snRSin_kJ_m2_etistep," //61
-				<<"Uerror_kJ_m2_etistep," //62
-				<<"IntSWEq_cm,"		 //63
-				<<"IntSub_cm,"		 //64
-				<<"IntSnUnload_cm,"	 //65
-				<<"CanStorage_mm," //66
-				<<"CumIntercept_mm," //67
-				<<"Interception_mm," //68
-				<<"Recharge_mm/hr," //69
-				<<"RunOn_mm," //70
-				<<"Srf_Hour_mm," //71
-				<<"Qstrm_m3_s," //72
-				<<"Hlevel_m," //73
-				<<"ThroughFall_[]," //74
-				<<"CanFieldCap_mm," //75
-				<<"DrainCoeff_mm_hr," //76
-				<<"DrainExpPar_1_mm," //77
-				<<"LandUseAlb_[]," //78
-				<<"VegHeight_m," //79
+				<<"LngRadIn_W_m2,"
+				<<"LngRadOut_W_m2A,"
+				<<"PotEvp_mm_h,"
+				<<"ActEvp_mm_h,"
+				<<"EvpTtrs_mm_h,"      //35
+				<<"EvpWetCan_mm_h,"
+				<<"EvpDryCan_mm_h,"
+				<<"EvpSoil_mm_h,"
+				<<"Gflux_W_m2,"
+				<<"HFlux_W_m2,"        //40
+				<<"Lflux_W_m2,"
+				<<"NetPrecip_mm_hr,"
+				<<"LiqWE_cm,"
+				<<"IceWE_cm,"
+				<<"SnWE_cm,"           //45
+				<<"SnSub_cm,"
+				<<"SnEvap_cm,"
+				<<"U_kJ_m2,"
+				<<"RouteWE_cm,"
+				<<"SnTemp_C,"          //50
+				<<"SurfAge_h,"
+				<<"SnDepth_cm,"
+				<<"SnDensity_kg_m3,"
+				<<"DU_kJ_m2,"
+				<<"snLHF_kJ_m2,"       //55
+				<<"snSHF_kJ_m2,"
+				<<"snGHF_kJ_m2,"
+				<<"snPHF_kJ_m2,"
+				<<"snRLout_kJ_m2,"
+				<<"snRLin_kJ_m2,"      //60
+				<<"snRSin_kJ_m2,"
+				<<"Uerror_kJ_m2,"
+				<<"IntSWEq_cm,"
+				<<"IntSub_cm,"
+				<<"IntSnUnload_cm,"     //65
+				<<"CanStorage_mm,"
+				<<"CumIntercept_mm,"
+				<<"Interception_mm,"
+				<<"Recharge_mm/hr,"
+				<<"RunOn_mm,"          //70
+				<<"Srf_Hour_mm,"
+				<<"Qstrm_m3_s,"
+				<<"Hlevel_m,"
+				<<"ThroughFall_[],"
+				<<"CanFieldCap_mm,"    //75
+				<<"DrainCoeff_mm_hr,"
+				<<"DrainExpPar_1_mm,"
+				<<"LandUseAlb_[],"
+				<<"VegHeight_m,"
 				<<"OptTransmCoeff_[]," //80
-				<<"StomRes_s_m," //81
-				<<"VegFraction[]," //82
-				<<"LeafAI_[]" //83
+				<<"StomRes_s_m,"
+				<<"VegFraction[],"
+				<<"LeafAI_[]"          //83
 				<<"\n";
 				
 				pixinfo[i].setf( ios::right, ios::adjustfield );
@@ -1272,79 +1272,79 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 	this->CreateAndOpenFile(&intofs, extension);
 
     
-	intofs << "ID" << ','    // 1
-		   << "BndCd" << ','    // 2
-		   << "Z" << ','    // 3
-		   << "VAr" << ','    // 4
-		   << "CAr" << ','    // 5
-		   << "Curv" << ','    // 6
-		   << "EdgL" << ','    // 7
-		   << "Slp" << ','    // 8
-		   << "FWidth" << ','    // 9
-		   << "Aspect" << ','    // 10
-		   << "SV" << ','    // 11
-		   << "LV" << ','    // 12
-		   << "AvSM" << ','    // 13
-		   << "AvRtM" << ','    // 14
-		   << "HOccr" << ','    // 15
-		   << "HRt" << ','    // 16
-		   << "SbOccr" << ','    // 17
-		   << "SbRt" << ','    // 18
-		   << "POccr" << ','    // 19
-		   << "PRt" << ','    // 20
-		   << "SatOccr" << ','    // 21
-		   << "SatRt" << ','    // 22
-		   << "SoiSatOccr" << ','    // 23
-		   << "RchDsch" << ','    // 24
-		   << "AvET" << ','    // 25
-		   << "EvpFrct" << ','    // 26
-		   << "cET" << ','  // 27
-		   << "cEsoil" << ',' // 28
-		   << "cLHF" << ','    // 29
-		   << "cMelt" << ','    // 30
-		   << "cSHF" << ','    // 31
-		   << "cPHF" << ','    // 32
-		   << "cRLIn" << ','    // 33
-		   << "cRLo" << ','    // 34
-		   << "cRSIn" << ','    // 35
-		   << "cGHF" << ','    // 36
-		   << "cUErr" << ','    // 37
-		   << "cHrsSun" << ','    // 38
-		   << "cHrsSnow" << ','    // 39
-		   << "persTime" << ','    // 40
-		   << "peakWE" << ','    // 41
-		   << "initTime" << ','    // 42
-		   << "peakTime" << ','    // 43
-		   << "cIntSub" << ','    // 44
-		   << "cSnSub" << ','    // 45
-		   << "cSnEvap" << ','    // 46
-		   << "cIntUnl" << ','    // 47
-		   << "AvTF" << ','    // 48
-		   << "AvCanFieldCap" << ','    // 49
-		   << "AvDrainCoeff" << ','    // 50
-		   << "AvDrainExpPar" << ','    // 51
-		   << "AvLUAlb" << ','    // 52
-		   << "AvVegHeight" << ','    // 53
-		   << "AvOTCoeff" << ','    // 54
-		   << "AvStomRes" << ','    // 55
-		   << "AvVegFract" << ','    // 56
-		   << "AvLeafAI" << ','    // 57
-		   << "AvEvapThresh" << ','    // 58
-		   << "AvTransThresh"    // 59
-		   << ',' << "Bedrock_Depth_mm"    // 60
-		   << ',' << "Ks"    // 61
-		   << ',' << "ThetaS"    // 62
-		   << ',' << "ThetaR"    // 63
-		   << ',' << "PoreSize"    // 64
-		   << ',' << "AirEBubPress"    // 65
-		   << ',' << "DecayF"    // 66
-		   << ',' << "SatAnRatio"    // 67
-		   << ',' << "UnsatAnRatio"    // 68
-		   << ',' << "Porosity"    // 69
-		   << ',' << "VolHeatCond"    // 70
-		   << ',' << "SoilHeatCap"    // 71
-		   << ',' << "SoilID"    // 72
-		   << ',' << "LandUseID"    // 73
+	intofs << "ID" << ','                                     // 1
+		   << "BndCd" << ','                                  // 2
+		   << "Z" << ','                                      // 3
+		   << "VAr" << ','                                    // 4
+		   << "CAr" << ','                                    // 5
+		   << "Curv" << ','                                   // 6
+		   << "EdgL" << ','                                   // 7
+		   << "Slp" << ','                                    // 8
+		   << "FWidth" << ','                                 // 9
+		   << "Aspect" << ','                                 // 10
+		   << "SV" << ','                                     // 11
+		   << "LV" << ','                                     // 12
+		   << "AvSM" << ','                                   // 13
+		   << "AvRtM" << ','                                  // 14
+		   << "HOccr" << ','                                  // 15
+		   << "HRt" << ','                                    // 16
+		   << "SbOccr" << ','                                 // 17
+		   << "SbRt" << ','                                   // 18
+		   << "POccr" << ','                                  // 19
+		   << "PRt" << ','                                    // 20
+		   << "SatOccr" << ','                                // 21
+		   << "SatRt" << ','                                  // 22
+		   << "SoiSatOccr" << ','                             // 23
+		   << "RchDsch" << ','                                // 24
+		   << "AvET" << ','                                   // 25
+		   << "EvpFrct" << ','                                // 26
+		   << "cET" << ','                                    // 27
+		   << "cEsoil" << ','                                 // 28
+		   << "cLHF" << ','                                   // 29
+		   << "cMelt" << ','                                  // 30
+		   << "cSHF" << ','                                   // 31
+		   << "cPHF" << ','                                   // 32
+		   << "cRLIn" << ','                                  // 33
+		   << "cRLo" << ','                                   // 34
+		   << "cRSIn" << ','                                  // 35
+		   << "cGHF" << ','                                   // 36
+		   << "cUErr" << ','                                  // 37
+		   << "cHrsSun" << ','                                // 38
+		   << "cHrsSnow" << ','                               // 39
+		   << "persTime" << ','                               // 40
+		   << "peakWE" << ','                                 // 41
+		   << "initTime" << ','                               // 42
+		   << "peakTime" << ','                               // 43
+		   << "cIntSub" << ','                                // 44
+		   << "cSnSub" << ','                                 // 45
+		   << "cSnEvap" << ','                                // 46
+		   << "cIntUnl" << ','                                // 47
+		   << "AvTF" << ','                                   // 48
+		   << "AvCanFieldCap" << ','                          // 49
+		   << "AvDrainCoeff" << ','                           // 50
+		   << "AvDrainExpPar" << ','                          // 51
+		   << "AvLUAlb" << ','                                // 52
+		   << "AvVegHeight" << ','                            // 53
+		   << "AvOTCoeff" << ','                              // 54
+		   << "AvStomRes" << ','                              // 55
+		   << "AvVegFract" << ','                             // 56
+		   << "AvLeafAI" << ','                               // 57
+		   << "AvEvapThresh" << ','                           // 58
+		   << "AvTransThresh" << ','                          // 59
+		   << "Bedrock_Depth_mm" << ','                       // 60
+		   << "Ks" << ','                                     // 61
+		   << "ThetaS" << ','                                 // 62
+		   << "ThetaR" << ','                                 // 63
+		   << "PoreSize" << ','                               // 64
+		   << "AirEBubPress" << ','                           // 65
+		   << "DecayF" << ','                                 // 66
+		   << "SatAnRatio" << ','                             // 67
+		   << "UnsatAnRatio" << ','                           // 68
+		   << "Porosity" << ','                               // 69
+		   << "VolHeatCond" << ','                            // 70
+		   << "SoilHeatCap" << ','                            // 71
+		   << "SoilID" << ','                                 // 72
+		   << "LandUseID"                                     // 73
 		   << "\n";
 	
 	cn = ni.FirstP();

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -1592,9 +1592,7 @@ void tCOutput<tSubNode>::CreateAndOpenOutlet()
 						cerr<<"File "<<fullName<<"can not be created.";
 					
 					// Write Header
-					outletinfo[i] << "Time_hr"  << ","
-					<< "Qstrm_m3/s" << ","
-					<< "Hlev_m"  << "\n";
+					outletinfo[i] << "Time_hr,Qstrm_m3_s,Hlev_m\n";
 				}
 			}
 		}


### PR DESCRIPTION
This pull request standardizes all time-series model output files to CSV format with `VariableName_units` column headers, targeting the upcoming v6.0.0 release.

Prior to this change, tRIBS output files used inconsistent formats: pixel files (.pixel) used tab-delimited multi-row headers, the mean response file (`.mrf`) and runoff type file (`.rft`) used fprintf-based tab-delimited rows with ambiguous time formatting (hour.minute as two integers rather than decimal hours), and the streamflow files (`.qout`) had mixed tab and space delimiters. This made post-processing across output types inconsistent and required format specific handling in analysis tools like pytRIBS. 

All output files now share a common format: a single header row with `VariableName_units` column names (e.g., `Time_hr`, `Srf_m3_s`, `MAP_mm_hr`) followed by comma-delimited data rows. Time is written as decimal hours throughout. This also corrects an issue in the pixel file where `getSrf()`, a per-computation-step variable reset every `dt` (~3.75 min), was written in place of `getSrf_Hr()`, which correctly accumulates runoff over the full output interval.

**Technical Changes (C++ / Inputs)**
* `src/tInOut/tOutput.cpp`: Pixel file (`.pixel`) header updated to CSV with `VariableName_units` format. Column 12 changed from `Srf_mm` to `Srf_Hour_mm` and the data write changed from `getSrf()` to `getSrf_Hr()`. The duplicate `Srf_Hour_mm` column (position 71) and its corresponding `getSrf_Hr()` data write were removed.                                                                                            
* `src/tFlowNet/tFlowResults.h`: Removed declarations for three dead functions (`read_prev_hyd`, `add_fore_hyd`, `write_extra_hyd`) that were linked to a legacy RIBS functionality and had no calls anywhere in the codebase. Removed `<cstdio>` include, no longer needed after migrating file writes from `fprintf` to `ofstream`.   
* `src/tFlowNet/tFlowResults.cpp`: `write_inter_hyd()` and `write_Runoff_Types()` rewritten from `fprintf/FILE*` to `ofstream`, matching the style used in `tOutput.cpp`. Both functions now write single-row CSV headers and comma-delimited data rows. Time corrected from `%d.%d` integer format to decimal hours. The three dead functions identified above removed in full.
* `src/tFlowNet/tKinemat.cpp`: Streamflow output file (`.qout`) header updated to `Time_hr,Qstrm_m3_s,Hlev_m` in both the serial constructor path and the parallel `openOutletFile()` path. Data row delimiters changed from tabs to commas.                                 