### PR TITLE
Refactor/remove legacy forecast

### DIFF
--- a/src/tFlowNet/tFlowResults.cpp
+++ b/src/tFlowNet/tFlowResults.cpp
@@ -195,9 +195,6 @@ void tFlowResults::SetFlowResVariables(tInputFile &infile, double add_time)
 	if ((frac = (double*)calloc(limit,sizeof(double)))==NULL)
 		cout<<"\ntFlowResults: frac failed..."<<endl;
 	
-	if ((fState = (int*)calloc(limit,sizeof(int)))==NULL)
-		cout<<"\ntFlowResults: fState failed..."<<endl;
-	
 	if ((qunsat = (double*)calloc(limit,sizeof(double)))==NULL) // CJC2025
 		cout<<"\ntFlowResults: qunsat failed..."<<endl;
 
@@ -209,7 +206,6 @@ void tFlowResults::SetFlowResVariables(tInputFile &infile, double add_time)
 		prr[i] = crr[i] = 0.0;
 		HsrfRout[i] = SbsrfRout[i] = 0.0;
 		PsrfRout[i] = SatsrfRout[i] = 0.0;
-		fState[i] = 0;
 		max[i]=sat[i]=msm[i]=mgw[i]=msmU[i]=msmRt[i]=met[i]=frac[i]=0.0;
 		      
 		// SKY2008Snow from AJR2007
@@ -255,7 +251,6 @@ void tFlowResults::free_results()
 	free(mgw);
 	free(met);
 	free(frac);
-	free(fState);
 	// SKY2008Snow from AJR2007
 	free(swe);
 	free(melt);
@@ -287,7 +282,6 @@ void tFlowResults::free_results()
 	SbsrfRout=NULL;
 	PsrfRout=NULL;
 	SatsrfRout=NULL;
-	fState=NULL;
 	max = NULL;
 	min = NULL;
 	msm = NULL;
@@ -333,7 +327,7 @@ void tFlowResults::free_results()
 
 /***************************************************************************
 **
-**  tFlowResults: writeAndUpdate(inter_hour, dt_rain)
+**  tFlowResults: writeAndUpdate(time)
 **
 **  Write basin state variables, output and result hydrographs
 **
@@ -345,16 +339,16 @@ void tFlowResults::free_results()
 **	call network model to write state and outputAlgorithm:
 **
 ***************************************************************************/
-void tFlowResults::writeAndUpdate( double time, int forenum )
-{ 
+void tFlowResults::writeAndUpdate( double time )
+{
 	int  hour, minute;
 	char timetag[20];
 	writeFlag = 0;
-	
+
 	if (simCtrl->Verbose_label == 'Y')
 		cout<<"\n\ttFlowResults: Time to write hydrograph; time = "
 			<<time<<endl<<flush;
-	
+
 	hour   = (int)floor(time);
 	minute = (int)floor((time-hour)*60);
 
@@ -362,8 +356,8 @@ void tFlowResults::writeAndUpdate( double time, int forenum )
 	strcpy( currHydroName, baseHydroName );
 	strcat( currHydroName, timetag );
 	strcat( currHydroName, Extension);
-	
-	write_inter_hyd(currHydroName, outlet, forenum);
+
+	write_inter_hyd(currHydroName, outlet);
 	
 	update_prev_hyd();
 	
@@ -381,29 +375,23 @@ void tFlowResults::writeAndUpdate( double time, int forenum )
 **  master writes the file.
 **
 **  Algorithm:
-**      assign forecast state flag if forecast option is active
 **      [parallel] reduce all basin-state arrays across processors
 **                 (sum for fluxes/states, min/max for rainfall)
 **      [parallel] restrict file writing to master processor
 **      write CSV header (variable_unit format, 32 columns)
 **      for each output time step:
 **          write decimal time, outlet streamflow, mean areal
-**          precipitation with spatial min/max, forecast state,
+**          precipitation with spatial min/max, 
 **          mean soil moisture at multiple depths, mean ET and
 **          groundwater level, saturation and rain coverage fractions,
 **          snow pack states and energy fluxes, snow interception,
 **          snow covered area, channel percolation, and unsaturated flow
 **
 ***************************************************************************/
-void tFlowResults::write_inter_hyd(char *filename, char *identification,
-								   int foreNum)
+void tFlowResults::write_inter_hyd(char *filename, char *identification)
 {
 	int ii;              //Loop counter 
 	int it_hour, it_min;  //Hours and minutes to print results 
-
-	// Assign Forecast State if Option != 0
-	if (timer->getoptForecast()!=0)
-		fState[count] = checkForecast();
 
 #ifdef PARALLEL_TRIBS
 
@@ -465,33 +453,32 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
 		      << "MAP_mm_hr,"        // 3
 		      << "RainMax_mm_hr,"    // 4
 		      << "RainMin_mm_hr,"    // 5
-		      << "FState_[],"        // 6
-		      << "MSM100_[],"        // 7
-		      << "MSMRt_[],"         // 8
-		      << "MSMU_[],"          // 9
-		      << "MDGW_mm,"          // 10
-		      << "MET_mm,"           // 11
-		      << "SatPercent_[],"    // 12
-		      << "RainPercent_[],"   // 13
-		      << "AvSWE_cm,"         // 14
-		      << "AvMelt_cm,"        // 15
-		      << "AvSnSub_cm,"       // 16
-		      << "AvSnEvap_cm,"      // 17
-		      << "AvSTC_C,"          // 18
-		      << "AvDUInt_kJ_m2,"    // 19
-		      << "AvSLHF_kJ_m2,"     // 20
-		      << "AvSSHF_kJ_m2,"     // 21
-		      << "AvSPHF_kJ_m2,"     // 22
-		      << "AvSGHF_kJ_m2,"     // 23
-		      << "AvSRLI_kJ_m2,"     // 24
-		      << "AvSRLO_kJ_m2,"     // 25
-		      << "AvSRSI_kJ_m2,"     // 26
-		      << "AvInSn_cm,"        // 27
-		      << "AvInSu_cm,"        // 28
-		      << "AvInUn_cm,"        // 29
-		      << "SCA_[],"           // 30
-		      << "ChannelPerc_m3,"   // 31
-		      << "Qunsat_mm_hr\n";   // 32
+		      << "MSM100_[],"        // 6
+		      << "MSMRt_[],"         // 7
+		      << "MSMU_[],"          // 8
+		      << "MDGW_mm,"          // 9
+		      << "MET_mm,"           // 10
+		      << "SatPercent_[],"    // 11
+		      << "RainPercent_[],"   // 12
+		      << "AvSWE_cm,"         // 13
+		      << "AvMelt_cm,"        // 14
+		      << "AvSnSub_cm,"       // 15
+		      << "AvSnEvap_cm,"      // 16
+		      << "AvSTC_C,"          // 17
+		      << "AvDUInt_kJ_m2,"    // 18
+		      << "AvSLHF_kJ_m2,"     // 19
+		      << "AvSSHF_kJ_m2,"     // 20
+		      << "AvSPHF_kJ_m2,"     // 21
+		      << "AvSGHF_kJ_m2,"     // 22
+		      << "AvSRLI_kJ_m2,"     // 23
+		      << "AvSRLO_kJ_m2,"     // 24
+		      << "AvSRSI_kJ_m2,"     // 25
+		      << "AvInSn_cm,"        // 26
+		      << "AvInSu_cm,"        // 27
+		      << "AvInUn_cm,"        // 28
+		      << "SCA_[],"           // 29
+		      << "ChannelPerc_m3,"   // 30
+		      << "Qunsat_mm_hr\n";   // 31
 		writeFlag = 1;
 
 		for (ii=0; ii < iimax; ii++) {
@@ -504,66 +491,64 @@ void tFlowResults::write_inter_hyd(char *filename, char *identification,
 			      << pCrr[ii]                     << ","  // 3  MAP_mm_hr
 			      << pMax[ii]                     << ","  // 4  RainMax_mm_hr
 			      << pMin[ii]                     << ","  // 5  RainMin_mm_hr
-			      << fState[ii]                   << ","  // 6  FState_[]
-			      << pMsm[ii]                     << ","  // 7  MSM100_[]
-			      << pMsmRt[ii]                   << ","  // 8  MSMRt_[]
-			      << pMsmU[ii]                    << ","  // 9  MSMU_[]
-			      << pMgw[ii]                     << ","  // 10 MDGW_mm
-			      << pMet[ii]                     << ","  // 11 MET_mm
-			      << pSat[ii]                     << ","  // 12 SatPercent_[]
-			      << pFrac[ii]                    << ","  // 13 RainPercent_[]
-			      << pSwe[ii]                     << ","  // 14 AvSWE_cm
-			      << pMelt[ii]                    << ","  // 15 AvMelt_cm
-			      << pSnSub[ii]                   << ","  // 16 AvSnSub_cm
-			      << pSnEvap[ii]                  << ","  // 17 AvSnEvap_cm
-			      << pStC[ii]                     << ","  // 18 AvSTC_C
-			      << pDUint[ii]                   << ","  // 19 AvDUInt_kJ_m2
-			      << pSlhf[ii]                    << ","  // 20 AvSLHF_kJ_m2
-			      << pSshf[ii]                    << ","  // 21 AvSSHF_kJ_m2
-			      << pSphf[ii]                    << ","  // 22 AvSPHF_kJ_m2
-			      << pSghf[ii]                    << ","  // 23 AvSGHF_kJ_m2
-			      << pSrli[ii]                    << ","  // 24 AvSRLI_kJ_m2
-			      << pSrlo[ii]                    << ","  // 25 AvSRLO_kJ_m2
-			      << pSrsi[ii]                    << ","  // 26 AvSRSI_kJ_m2
-			      << pIntsn[ii]                   << ","  // 27 AvInSn_cm
-			      << pIntsub[ii]                  << ","  // 28 AvInSu_cm
-			      << pIntunl[ii]                  << ","  // 29 AvInUn_cm
-			      << pSca[ii]                     << ","  // 30 SCA_[]
-			      << pPerc[ii]                    << ","  // 31 ChannelPerc_m3
-			      << pQunsat[ii]                  << "\n"; // 32 Qunsat_mm_hr
+			      << pMsm[ii]                     << ","  // 6  MSM100_[]
+			      << pMsmRt[ii]                   << ","  // 7  MSMRt_[]
+			      << pMsmU[ii]                    << ","  // 8  MSMU_[]
+			      << pMgw[ii]                     << ","  // 9  MDGW_mm
+			      << pMet[ii]                     << ","  // 10 MET_mm
+			      << pSat[ii]                     << ","  // 11 SatPercent_[]
+			      << pFrac[ii]                    << ","  // 12 RainPercent_[]
+			      << pSwe[ii]                     << ","  // 13 AvSWE_cm
+			      << pMelt[ii]                    << ","  // 14 AvMelt_cm
+			      << pSnSub[ii]                   << ","  // 15 AvSnSub_cm
+			      << pSnEvap[ii]                  << ","  // 16 AvSnEvap_cm
+			      << pStC[ii]                     << ","  // 17 AvSTC_C
+			      << pDUint[ii]                   << ","  // 18 AvDUInt_kJ_m2
+			      << pSlhf[ii]                    << ","  // 19 AvSLHF_kJ_m2
+			      << pSshf[ii]                    << ","  // 20 AvSSHF_kJ_m2
+			      << pSphf[ii]                    << ","  // 21 AvSPHF_kJ_m2
+			      << pSghf[ii]                    << ","  // 22 AvSGHF_kJ_m2
+			      << pSrli[ii]                    << ","  // 23 AvSRLI_kJ_m2
+			      << pSrlo[ii]                    << ","  // 24 AvSRLO_kJ_m2
+			      << pSrsi[ii]                    << ","  // 25 AvSRSI_kJ_m2
+			      << pIntsn[ii]                   << ","  // 26 AvInSn_cm
+			      << pIntsub[ii]                  << ","  // 27 AvInSu_cm
+			      << pIntunl[ii]                  << ","  // 28 AvInUn_cm
+			      << pSca[ii]                     << ","  // 29 SCA_[]
+			      << pPerc[ii]                    << ","  // 30 ChannelPerc_m3
+			      << pQunsat[ii]                  << "\n"; // 31 Qunsat_mm_hr
 #else
 			ifile << time_hr                      << ","  // 1  Time_hr
 			      << phydro[ii]+mhydro[ii]        << ","  // 2  Srf_m3_s
 			      << crr[ii]                      << ","  // 3  MAP_mm_hr
 			      << max[ii]                      << ","  // 4  RainMax_mm_hr
 			      << min[ii]                      << ","  // 5  RainMin_mm_hr
-			      << fState[ii]                   << ","  // 6  FState_[]
-			      << msm[ii]                      << ","  // 7  MSM100_[]
-			      << msmRt[ii]                    << ","  // 8  MSMRt_[]
-			      << msmU[ii]                     << ","  // 9  MSMU_[]
-			      << mgw[ii]                      << ","  // 10 MDGW_mm
-			      << met[ii]                      << ","  // 11 MET_mm
-			      << sat[ii]                      << ","  // 12 SatPercent_[]
-			      << frac[ii]                     << ","  // 13 RainPercent_[]
-			      << swe[ii]                      << ","  // 14 AvSWE_cm
-			      << melt[ii]                     << ","  // 15 AvMelt_cm
-			      << snsub[ii]                    << ","  // 16 AvSnSub_cm
-			      << snevap[ii]                   << ","  // 17 AvSnEvap_cm
-			      << stC[ii]                      << ","  // 18 AvSTC_C
-			      << DUint[ii]                    << ","  // 19 AvDUInt_kJ_m2
-			      << slhf[ii]                     << ","  // 20 AvSLHF_kJ_m2
-			      << sshf[ii]                     << ","  // 21 AvSSHF_kJ_m2
-			      << sphf[ii]                     << ","  // 22 AvSPHF_kJ_m2
-			      << sghf[ii]                     << ","  // 23 AvSGHF_kJ_m2
-			      << srli[ii]                     << ","  // 24 AvSRLI_kJ_m2
-			      << srlo[ii]                     << ","  // 25 AvSRLO_kJ_m2
-			      << srsi[ii]                     << ","  // 26 AvSRSI_kJ_m2
-			      << intsn[ii]                    << ","  // 27 AvInSn_cm
-			      << intsub[ii]                   << ","  // 28 AvInSu_cm
-			      << intunl[ii]                   << ","  // 29 AvInUn_cm
-			      << sca[ii]                      << ","  // 30 SCA_[]
-			      << Perc[ii]                     << ","  // 31 ChannelPerc_m3
-			      << qunsat[ii ]                   << "\n"; // 32 Qunsat_mm_hr
+			      << msm[ii]                      << ","  // 6  MSM100_[]
+			      << msmRt[ii]                    << ","  // 7  MSMRt_[]
+			      << msmU[ii]                     << ","  // 8  MSMU_[]
+			      << mgw[ii]                      << ","  // 9  MDGW_mm
+			      << met[ii]                      << ","  // 10 MET_mm
+			      << sat[ii]                      << ","  // 11 SatPercent_[]
+			      << frac[ii]                     << ","  // 12 RainPercent_[]
+			      << swe[ii]                      << ","  // 13 AvSWE_cm
+			      << melt[ii]                     << ","  // 14 AvMelt_cm
+			      << snsub[ii]                    << ","  // 15 AvSnSub_cm
+			      << snevap[ii]                   << ","  // 16 AvSnEvap_cm
+			      << stC[ii]                      << ","  // 17 AvSTC_C
+			      << DUint[ii]                    << ","  // 18 AvDUInt_kJ_m2
+			      << slhf[ii]                     << ","  // 19 AvSLHF_kJ_m2
+			      << sshf[ii]                     << ","  // 20 AvSSHF_kJ_m2
+			      << sphf[ii]                     << ","  // 21 AvSPHF_kJ_m2
+			      << sghf[ii]                     << ","  // 22 AvSGHF_kJ_m2
+			      << srli[ii]                     << ","  // 23 AvSRLI_kJ_m2
+			      << srlo[ii]                     << ","  // 24 AvSRLO_kJ_m2
+			      << srsi[ii]                     << ","  // 25 AvSRSI_kJ_m2
+			      << intsn[ii]                    << ","  // 26 AvInSn_cm
+			      << intsub[ii]                   << ","  // 27 AvInSu_cm
+			      << intunl[ii]                   << ","  // 28 AvInUn_cm
+			      << sca[ii]                      << ","  // 29 SCA_[]
+			      << Perc[ii]                     << ","  // 30 ChannelPerc_m3
+			      << qunsat[ii ]                   << "\n"; // 31 Qunsat_mm_hr
 #endif
 		}
 
@@ -1063,36 +1048,6 @@ void tFlowResults::store_saturation(double time, double value, int flag)
 	return;
 }
 
-/*****************************************************************************
-**  
-**  tFlowResults::checkForecast()
-**  
-**  Check the forecast state. Returns integer representing state:
-**  
-**  0 = Before and up to forecast time, Use QPE
-**  1 = In Forecast Period and up to lead time, Use QPF
-**  2 = In Forecast Period and after lead time, Use Average Rainfall
-**  3 = After Forecast Period, End simulation
-**
-*****************************************************************************/
-int tFlowResults::checkForecast() 
-{
-	int state {};
-	
-	if (timer->getCurrentTime() < timer->getfTime())
-		state = 0;
-	else if (timer->getCurrentTime() < (timer->getfTime() + timer->getfLead()) &&
-			 timer->getCurrentTime() >= timer->getfTime())
-		state = 1;
-	else if (timer->getCurrentTime() < (timer->getfTime() + timer->getfLength()) &&
-			 timer->getCurrentTime() >= timer->getfLead())
-		state = 2;
-	else if (timer->getCurrentTime() >= (timer->getfTime() + timer->getfLength()))
-		state = 3;
-	
-	return state;
-}
-
 /***************************************************************************
 **
 ** tFlowResults::writeRestart() Function
@@ -1107,8 +1062,6 @@ void tFlowResults::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, iimax);
   BinaryWrite(rStr, writeFlag);
   BinaryWrite(rStr, count);
-  for (int i = 0; i < limit; i++)
-    BinaryWrite(rStr, fState[i]);
 
   for (int i = 0; i < limit; i++) {
     BinaryWrite(rStr, prr[i]);
@@ -1162,8 +1115,6 @@ void tFlowResults::readRestart(fstream & rStr)
   BinaryRead(rStr, iimax);
   BinaryRead(rStr, writeFlag);
   BinaryRead(rStr, count);
-  for (int i = 0; i < limit; i++)
-    BinaryRead(rStr, fState[i]);
 
   for (int i = 0; i < limit; i++) {
     BinaryRead(rStr, prr[i]);

--- a/src/tFlowNet/tFlowResults.h
+++ b/src/tFlowNet/tFlowResults.h
@@ -107,16 +107,13 @@ public:
   double *Perc; 	// Percolation from the channel bottom ASM percolation option
   double *qunsat;		// Mean net flow froom unsaturated zone CJC2025
 
-  int *fState;                  // Forecast state
-
-  int   checkForecast();
-  void  SetFlowResVariables(tInputFile &, double); 
-  void  writeAndUpdate(double, int);
+  void  SetFlowResVariables(tInputFile &, double);
+  void  writeAndUpdate(double);
   void  store_rain(double,double);
   void  store_maxminrain(double,double, int);
   void  store_saturation(double,double, int);
   void  free_results();
-  void  write_inter_hyd(char *, char *, int);
+  void  write_inter_hyd(char *, char *);
   void  write_Runoff_Types(char *, char *);
   void  whenTimeIsOver( double );
   void  store_volume(double, double);          

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -2330,11 +2330,15 @@ double tEvapoTrans::rtsafe_mod_energy(tCNode* cNode, double x1, double x2,
 		else
 			xh=rts;
 	}
-	cerr<<"\n\t\ttEvapotrans: Energy balance: NO convergence in "<<MAXITER<<"\n";
-	cerr<<"\t ERROR = "<<f
-		<<";  Initial = "<<xguess
-		<<";  Last estimate = "<<rts<<";  ID = "<<ID
-		<<"\n\t##### Initial value is kept."<<endl<<endl<<flush;
+	static int warnEBconv = 0;
+	if (++warnEBconv <= 10)
+		cerr<<"\n\t\ttEvapotrans: Energy balance: NO convergence in "<<MAXITER<<"\n"
+			<<"\t ERROR = "<<f
+			<<";  Initial = "<<xguess
+			<<";  Last estimate = "<<rts<<";  ID = "<<ID
+			<<"\n\t##### Initial value is kept."<<endl<<endl<<flush;
+	else if (warnEBconv == 11)
+		cerr<<"\n\t\ttEvapotrans: Energy balance: NO convergence (further warnings suppressed)"<<endl<<flush;
 	return xguess;
 }
 #undef MAXITER

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -2630,7 +2630,7 @@ void tEvapoTrans::DeriveAspect()
 ***************************************************************************/
 void tEvapoTrans::EvapPenmanMonteith(tCNode* cNode) 
 {
-	potEvap = 3600.0*energyBalance(cNode);   // Actual rate, including resistances
+	potEvap = 3600.0*energyBalance(cNode);   // Reference rate (rs=0); stomatal resistance applied later in ComputeETComponents via transFactor
 	actEvap = 3600.0*(lFlux/(latentHeat()));  
 }
 

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -1361,8 +1361,13 @@ void tHydroModel::UnSaturatedZone(double dt)
 									BB = -dt*(qn - R1)/(Ths-Thr) - Eps/F*exp(-F*NtOld/Eps);
 									AA = -exp(F*(BB-NtOld)/Eps);
 									NtNew = NtOld + (Eps/F*LambertW(AA) - BB);
-									if (AA < (-1/exp(1.0)))
-										cout<<"\nWarning: Value for LAMBERT f-n is too small\n\n";
+									if (AA < (-1/exp(1.0))) {
+										static int warnLambert1 = 0;
+										if (++warnLambert1 <= 10)
+											cout<<"\nWarning: Value for LAMBERT f-n is too small\n\n";
+										else if (warnLambert1 == 11)
+											cout<<"\nWarning: Value for LAMBERT f-n is too small (further warnings suppressed)\n\n";
+									}
 									RuNew = Ksat*exp(-F*NtNew);
 								}
 							}
@@ -1512,12 +1517,21 @@ void tHydroModel::UnSaturatedZone(double dt)
 
 						if ((RiNew-RuNew) < 1.0E-2 && (RiNew - RuNew) > 0.0)
 							RuNew = RiNew;
-						else if ((RiNew-RuNew) > 1.0E-2)
-							cout<<"\nWarning: UNSAT: RuNew < RiNew: id = "<<cn->getID()<<"\n";
+						else if ((RiNew-RuNew) > 1.0E-2) {
+							static int warnRuRi = 0;
+							if (++warnRuRi <= 10)
+								cout<<"\nWarning: UNSAT: RuNew < RiNew: id = "<<cn->getID()<<"\n";
+							else if (warnRuRi == 11)
+								cout<<"\nWarning: UNSAT: RuNew < RiNew (further warnings suppressed)\n";
+						}
 
 						if (RuNew > Ksat) {
-							cout<<"\nWarning: UNSAT: RuNew > Ksat: id = "
-							<<cn->getID()<<"\n\tRuNew = "<<RuNew<<"\tKsat = "<<Ksat<<"\n";
+							static int warnRuKsat = 0;
+							if (++warnRuKsat <= 10)
+								cout<<"\nWarning: UNSAT: RuNew > Ksat: id = "
+								<<cn->getID()<<"\n\tRuNew = "<<RuNew<<"\tKsat = "<<Ksat<<"\n";
+							else if (warnRuKsat == 11)
+								cout<<"\nWarning: UNSAT: RuNew > Ksat (further warnings suppressed)\n";
 						}
                     }
 				}
@@ -1543,9 +1557,14 @@ void tHydroModel::UnSaturatedZone(double dt)
                                 hsrf += (R1 - (qn - RiOld*Cos));
                                 R1 -= hsrf;
                             }
-                            else
-                                cout<<"\nWarning: Wrong state def.: R < Keqviv-RiOld*Cos: id = "
-                                <<cn->getID()<<"\n\n";
+                            else {
+                                static int warnStateDef1 = 0;
+                                if (++warnStateDef1 <= 10)
+                                    cout<<"\nWarning: Wrong state def.: R < Keqviv-RiOld*Cos: id = "
+                                    <<cn->getID()<<"\n\n";
+                                else if (warnStateDef1 == 11)
+                                    cout<<"\nWarning: Wrong state def.: R < Keqviv-RiOld*Cos (further warnings suppressed)\n\n";
+                            }
 
                             NtNew = 0.0;
                             MuNew = MuOld + R1*dt;
@@ -1754,8 +1773,13 @@ void tHydroModel::UnSaturatedZone(double dt)
                         else {
                             BB = -dt*(qn - R1)/(Ths-Thr) - Eps/F*exp(-F*NtOld/Eps);
                             AA = -exp(F*(BB-NtOld)/Eps);
-                            if (AA < (-1.0/exp(1.0)))
-                                cout<<"\n\n\t\tWarning: Value for LAMBERT f-n is too small\n\n";
+                            if (AA < (-1.0/exp(1.0))) {
+                                static int warnLambert2 = 0;
+                                if (++warnLambert2 <= 10)
+                                    cout<<"\n\n\t\tWarning: Value for LAMBERT f-n is too small\n\n";
+                                else if (warnLambert2 == 11)
+                                    cout<<"\n\n\t\tWarning: Value for LAMBERT f-n is too small (further warnings suppressed)\n\n";
+                            }
                             NtNew = NtOld + (Eps/F*LambertW(AA) - BB);
                             RuNew = Ksat*exp(-F*NtNew);
                         }
@@ -1845,8 +1869,12 @@ void tHydroModel::UnSaturatedZone(double dt)
 							}
 
 							else {
-						    	    cout<<"\nWarning: WRONG state def.: R < Keqviv-RiOld*Cos: id = "
-								<<cn->getID()<<"\n\n";
+								static int warnStateDef2 = 0;
+								if (++warnStateDef2 <= 10)
+									cout<<"\nWarning: WRONG state def.: R < Keqviv-RiOld*Cos: id = "
+									<<cn->getID()<<"\n\n";
+								else if (warnStateDef2 == 11)
+									cout<<"\nWarning: WRONG state def.: R < Keqviv-RiOld*Cos (further warnings suppressed)\n\n";
                             }
 
 							NtNew = 0.0;

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -519,6 +519,7 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
             liqRoute = 0.0;
             iceWE = 0.0;
             liqWE = 0.0;
+            snDepthm = 0.0;
             Utot = 0.0;
             Usn = 0.0;
             Uwat = 0.0;
@@ -1221,7 +1222,7 @@ void tSnowPack::setToNodeSnP(tCNode *node) {
     node->setSnDepth(snDepthm * 100.0); 
 
     //cumulative outputs
-    node->addLatHF(L);
+    node->addLatHF(L * timeSteps);
     node->addSnSub(snSub); // cumulative snow sublimation CJC2020
     node->addSnEvap(snEvap); // cumulative snow evaporation CJC2020
     node->addMelt(liqRoute);
@@ -1565,12 +1566,12 @@ double tSnowPack::precipitationHFCalc() {
     liqPrec = ((1 - snowFracCalc()) * (rain + ctom * snUnload)) * mtoc; //convert from mm to cm
 
     if (airTemp > 0) {
-        phf = (cmtonaught * snPrec * 0 * rholiqkg * cpicekJ +
-               cmtonaught * liqPrec * (latFreezekJ + airTemp * rholiqkg * cpwaterkJ)) / 3600;
+        // snPrec term is zero (ice assumed to be at 0C on arrival)
+        phf = (cmtonaught * liqPrec * rholiqkg * (latFreezekJ + airTemp * cpwaterkJ)) / 3600;
 
-    } else if (airTemp <= 0) {
+    } else {
         phf = (cmtonaught * snPrec * airTemp * rholiqkg * cpicekJ +
-               cmtonaught * liqPrec * latFreezekJ * rholiqkg) / 3600;
+               cmtonaught * liqPrec * rholiqkg * latFreezekJ) / 3600;
 
     }
 
@@ -1764,10 +1765,9 @@ void tSnowPack::computeSub() {
     acoefficient = beta * coeffLAI;
 
     //find windspeed
-    if (windSpeed == 0.0) {
-        windSpeedC = 0.1; // WR 01032024 switched to windSpeedC since that is what is set to node.
-    }
-    windSpeedC = windSpeed * exp(-acoefficient * 0.4);// WR 01032024 switched to windSpeedC since that is what is set to node.
+    windSpeedC = windSpeed * exp(-acoefficient * 0.4);
+    if (windSpeedC == 0.0)
+        windSpeedC = 0.1;
 
     //Calculate Reynolds number
     Re = 2 * iceRad * windSpeedC / nu;

--- a/src/tRasTin/tRainfall.cpp
+++ b/src/tRasTin/tRainfall.cpp
@@ -53,11 +53,8 @@ void tRainfall::SetRainVariables(tInputFile &inFile)
 { 
 	rainfallType = inFile.ReadItem(rainfallType, "RAINSOURCE");
 	rainDt = inFile.ReadItem(rainDt, "RAININTRVL");
-	fState = 0;     //Default values
-	optMAP = 0;  
-	climate = 0.0; 
-	optForecast = 0;  
-	
+	optMAP = 0;
+
 	// If data are used as the model forcing
 	if (rainfallType == 1)
 		Cout<<"Rainfall Source: \t\tGridded Rainfall [mm/hr]\n";
@@ -105,20 +102,6 @@ void tRainfall::SetRainVariables(tInputFile &inFile)
 		exit(1);
 	}
 	
-	// Get Forecast File Directory, use same extension
-	optForecast = inFile.ReadItem(optForecast, "FORECASTMODE"); 
-
-	if (optForecast == 1) {
-		inFile.ReadItem(forecastname, "FORECASTFILE");
-	}
-	else if (optForecast == 3) {
-		climate = inFile.ReadItem(climate, "CLIMATOLOGY");
-	}
-	
-	// Re-initialize average, cumulative MAP and # rainfall files
-	numRains = 0;
-	aveMAP = 0.0;
-	cumMAP = 0.0;
 }
 
 // Destructor
@@ -163,42 +146,15 @@ int tRainfall::Compose_In_Mrain_Name(tRunTimer *t)
     if ( infile.is_open() )
 		infile.close();
 	
-	// Read rainfall file depending on forecast state
-	if (fState == 0) {
-		
-		if (t->minuteRn || t->dtRain < 1) //If 'minute' is NOT equal to '0'  
-			snprintf(mrainfileIn,sizeof(mrainfileIn), "%s%02d%02d%04d%02d%02d.%s", inputname,
-					t->monthRn, t->dayRn, t->yearRn, t->hourRn, t->minuteRn, extension);//WR--09192023:'sprintf' is deprecated: This function is provided for compatibility reasons only.
-		else {           //If 'minute' IS equal to '0'
-			snprintf(mrainfileIn,sizeof(mrainfileIn),"%s%02d%02d%04d%02d.%s", inputname,
-					t->monthRn, t->dayRn, t->yearRn, t->hourRn, extension);//WR--09192023:'sprintf' is deprecated: This function is provided for compatibility reasons only.
-		}
-		infile.open(mrainfileIn);
+	if (t->minuteRn || t->dtRain < 1)
+		snprintf(mrainfileIn,sizeof(mrainfileIn), "%s%02d%02d%04d%02d%02d.%s", inputname,
+				t->monthRn, t->dayRn, t->yearRn, t->hourRn, t->minuteRn, extension);
+	else {
+		snprintf(mrainfileIn,sizeof(mrainfileIn),"%s%02d%02d%04d%02d.%s", inputname,
+				t->monthRn, t->dayRn, t->yearRn, t->hourRn, extension);
 	}
-	
-	else if (fState == 1) {
-		
-		if (t->getoptForecast() == 1) {
-			if (t->minuteRn || t->dtRain < 1) //If 'minute' is NOT equal to '0'  
-				snprintf(mrainfileIn,sizeof(mrainfileIn), "%s%02d%02d%04d%02d%02d.%s", forecastname,
-						t->monthRn, t->dayRn, t->yearRn, t->hourRn, t->minuteRn, extension); //WR--09192023:'sprintf' is deprecated: This function is provided for compatibility reasons only.
-			else {           //If 'minute' IS equal to '0'
-				snprintf(mrainfileIn,sizeof(mrainfileIn),"%s%02d%02d%04d%02d.%s", forecastname,
-						t->monthRn, t->dayRn, t->yearRn, t->hourRn, extension);//WR--09192023:'sprintf' is deprecated: This function is provided for compatibility reasons only.
-			}
-			infile.open(mrainfileIn);
-		}
-		else if (t->getoptForecast() == 2) {   //Persistence
-			infile.open(mrainfileIn);
-		}
-		else if (t->getoptForecast() == 3) {  //Climatology
-			return 1;
-		}
-	}
-	
-	else if (fState == 2)
-		return 1;
-	
+	infile.open(mrainfileIn);
+
 	// Check if file opened
     if ( !(infile.is_open()) )
 		return 0;
@@ -273,68 +229,27 @@ void tRainfall::NewRain(tRunTimer *t)
 	
 	id = 0;
 	cn = nodeIter.FirstP();
-	
-	// FSTATE == 0 OR 1
-	if (fState == 0 || fState == 1) {
-		
-		curRain = respPtr->doIt(mrainfileIn, 1);
-		
-		// Check Valid Rainfall and Compute MAP 
-		while( nodeIter.IsActive() ) {
-			if (curRain[id] < 0.0 || curRain[id] > maxRain*t->getRainDT())
-				curRain[id] = 0.0;
-			sumRain = sumRain + cn->getVArea()*curRain[id];   
-			sumArea = sumArea + cn->getVArea();
-			cn = nodeIter.NextP();
-			id++; 
-		}
-		
-		// Compute cum and ave MAPs over time prior to forecast
-		// conditioned on rain occuring (sumRain > 0)
-		if (fState == 0 && sumRain > 0) {
-			numRains++;
-			cumMAP += sumRain/sumArea;
-			aveMAP = cumMAP/numRains;
-		}
-		
-		// Assign Rainfall Values
-		id = 0;
-		cn = nodeIter.FirstP();
-		while( nodeIter.IsActive() ) { 
-			// Assign MAP to curRain for optMAP = 1
-			if (optMAP == 1)
-				curRain[id]=sumRain/sumArea;
-			if (rainfallType == 1)
-				cn->setRain( curRain[id]/t->getRainDT());      //Gridded - mm/hour
-			cn = nodeIter.NextP();
-			id++;
-		}
-		
-		// Climatological forecast for FState == 1
-		cn = nodeIter.FirstP();
-		if (fState == 1 && t->getoptForecast() == 3) {
-			while( nodeIter.IsActive() ) {
-				cn->setRain( climate ); 
-				cn = nodeIter.NextP();
-			}
-		}
+
+	curRain = respPtr->doIt(mrainfileIn, 1);
+
+	while( nodeIter.IsActive() ) {
+		if (curRain[id] < 0.0 || curRain[id] > maxRain*t->getRainDT())
+			curRain[id] = 0.0;
+		sumRain = sumRain + cn->getVArea()*curRain[id];
+		sumArea = sumArea + cn->getVArea();
+		cn = nodeIter.NextP();
+		id++;
 	}
-	
-	// FSTATE == 2
-	else if (fState == 2) {
-		if (t->getoptForecast() != 3) {
-			while( nodeIter.IsActive() ) {    
-				if (rainfallType == 1)
-					cn->setRain( aveMAP );      //Gridded - mm/hour
-				cn = nodeIter.NextP();
-			}
-		}
-		else {    //Climatological forecast
-			while( nodeIter.IsActive() ) {    
-				cn->setRain( climate ); 
-				cn = nodeIter.NextP();
-			}
-		}
+
+	id = 0;
+	cn = nodeIter.FirstP();
+	while( nodeIter.IsActive() ) {
+		if (optMAP == 1)
+			curRain[id]=sumRain/sumArea;
+		if (rainfallType == 1)
+			cn->setRain( curRain[id]/t->getRainDT());
+		cn = nodeIter.NextP();
+		id++;
 	}
 
 	return;
@@ -818,18 +733,6 @@ void tRainfall::setToNode()
 
 /***************************************************************************
 **
-** tRainfall::setfState() Function
-**
-** Functions used to set the values of fState
-**
-***************************************************************************/
-void tRainfall::setfState(int state) 
-{ 
-	fState = state;
-}
-
-/***************************************************************************
-**
 ** tRainfall::writeRestart() Function
 ** 
 ** Called from tSimulator during simulation loop
@@ -842,9 +745,6 @@ void tRainfall::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, numStations);
   BinaryWrite(rStr, arraySize);
   BinaryWrite(rStr, hourlyTimeStep);
-  BinaryWrite(rStr, numRains);
-  BinaryWrite(rStr, optForecast);
-  BinaryWrite(rStr, fState);
   BinaryWrite(rStr, optMAP);
   BinaryWrite(rStr, rainDt);
 
@@ -861,9 +761,6 @@ void tRainfall::writeRestart(fstream & rStr) const
   }
 
   BinaryWrite(rStr, precLapseRate);
-  BinaryWrite(rStr, aveMAP);
-  BinaryWrite(rStr, cumMAP);
-  BinaryWrite(rStr, climate);
 }
 
 /***************************************************************************
@@ -878,9 +775,6 @@ void tRainfall::readRestart(fstream & rStr)
   BinaryRead(rStr, numStations);
   BinaryRead(rStr, arraySize);
   BinaryRead(rStr, hourlyTimeStep);
-  BinaryRead(rStr, numRains);
-  BinaryRead(rStr, optForecast);
-  BinaryRead(rStr, fState);
   BinaryRead(rStr, optMAP);
   BinaryRead(rStr, rainDt);
 
@@ -897,9 +791,6 @@ void tRainfall::readRestart(fstream & rStr)
   }
 
   BinaryRead(rStr, precLapseRate);
-  BinaryRead(rStr, aveMAP);
-  BinaryRead(rStr, cumMAP);
-  BinaryRead(rStr, climate);
 }
 
 //=========================================================================

--- a/src/tRasTin/tRainfall.h
+++ b/src/tRasTin/tRainfall.h
@@ -54,7 +54,6 @@ public:
   void assignStationToNode();
   void callRainGauge(tRunTimer *);
   void setToNode();
-  void setfState(int);
   void writeRestart(fstream &) const;
   void readRestart(fstream &);
   
@@ -68,7 +67,7 @@ protected:
   tMesh<tCNode> *gridPtr;
   tResample     *respPtr;
   tRainGauge * rainGauges;
-  int numStations, arraySize, hourlyTimeStep, numRains;
+  int numStations, arraySize, hourlyTimeStep;
   int *assignedRain, *currentTime;
   double *curRain, *latitude, *longitude, *gaugeRain; 
 
@@ -76,11 +75,9 @@ protected:
   double precLapseRate;//AJR @ NMT 2007
 
   char inputname[kMaxNameSize];
-  char forecastname[kMaxNameSize];
   char stationFile[kName];
-  char extension[20]; 
-  double aveMAP, cumMAP, climate;   
-  int optForecast, fState, optMAP;
+  char extension[20];
+  int optMAP;
   ifstream infile; 
 };
 

--- a/src/tSimulator/tPreProcess.cpp
+++ b/src/tSimulator/tPreProcess.cpp
@@ -71,7 +71,7 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 	// SKY2008Snow from AJR2007
 	int optradshelt; //, optwindshelt;
 
-	int optfrcst, optgw;
+	int optgw;
    int optpar, optgraph, optrest, optv;
 	char tempString[kName];
 
@@ -123,7 +123,7 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 	IterReadItem(infile, tempVariable,"OPTRADSHELT");
 
 
-	optmesh=optrain=optrock=optmet=optfrcst=optgw=0; //Int
+	optmesh=optrain=optrock=optmet=optgw=0; //Int
   	optpar=optgraph=optrest=0;
 
 	optres=0; // JECR 2015
@@ -142,7 +142,6 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 	}
 
 	optrock  = IterReadItem(infile, optrock ,"OPTBEDROCK");
-	optfrcst = IterReadItem(infile, optfrcst,"FORECASTMODE");
 	//optgw    = IterReadItem(infile, optgw,   "OPTGWFILE");
 	
 	optres = IterReadItem(infile, tempVariable,"OPTRESERVOIR"); // JECR 2015
@@ -254,16 +253,6 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 	IterReadItem(infile, tempString,"HYDRONODELIST");
 	IterReadItem(infile, tempString,"OUTLETNODELIST");
 
-	if (optfrcst != 0 ) {                //Forecasting
-		IterReadItem(infile, tempVariable,"FORECASTTIME");
-		IterReadItem(infile, tempVariable,"FORECASTLEADTIME");
-		IterReadItem(infile, tempVariable,"FORECASTLENGTH");
-	}
-	else if (optfrcst == 1)
-		IterReadItem(infile, tempString,  "FORECASTFILE");
-	else if (optfrcst == 3)
-		IterReadItem(infile, tempVariable,"CLIMATOLOGY");
-	
    // Restart options
    optrest = IterReadItem(infile, optrest, "RESTARTMODE");
    if (optrest > 0) {

--- a/src/tSimulator/tRunTimer.cpp
+++ b/src/tSimulator/tRunTimer.cpp
@@ -179,14 +179,6 @@ void tRunTimer::InitializeTimer( tInputFile &infile )
 	else
 		etistep = dtRain;
 
-	// Rainfall Forecast Times
-	optForecast = infile.ReadItem(optForecast, "FORECASTMODE");
-	if (optForecast != 0) {
-		fTime = infile.ReadItem(fTime, "FORECASTTIME");
-		fLength = infile.ReadItem(fLength, "FORECASTLENGTH");
-		fLead = infile.ReadItem(fLead, "FORECASTLEADTIME");
-	}
-	
 	// Adjustments to Time with Rainfall Input
 	
 	double help;
@@ -534,21 +526,6 @@ double tRunTimer::res_hour_end(int it)
 
 /***************************************************************************
 **
-** tRunTimer::Get Rainfall Forecasting Functions
-**
-**
-***************************************************************************/
-
-double tRunTimer::getfTime() { return fTime; }
-
-double tRunTimer::getfLength() { return fLength; }
-
-double tRunTimer::getfLead() { return fLead; }
-
-int tRunTimer::getoptForecast() { return optForecast; }
-
-/***************************************************************************
-**
 ** tWaterBalance::writeRestart() Function
 ** 
 ** Called from tSimulator during simulation loop
@@ -576,7 +553,6 @@ void tRunTimer::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, dayS);
   BinaryWrite(rStr, monthS);
   BinaryWrite(rStr, yearS);
-  BinaryWrite(rStr, optForecast);
   BinaryWrite(rStr, dtRain);
   BinaryWrite(rStr, startHour);
   BinaryWrite(rStr, currentTime);
@@ -588,9 +564,6 @@ void tRunTimer::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, outputInterval);
   BinaryWrite(rStr, SPOutputInterval);
   BinaryWrite(rStr, RainTime);
-  BinaryWrite(rStr, fTime);
-  BinaryWrite(rStr, fLength);
-  BinaryWrite(rStr, fLead);
   BinaryWrite(rStr, etistep);
   BinaryWrite(rStr, MetTime);
   BinaryWrite(rStr, EtITime);
@@ -623,7 +596,6 @@ void tRunTimer::readRestart(fstream & rStr)
   BinaryRead(rStr, dayS);
   BinaryRead(rStr, monthS);
   BinaryRead(rStr, yearS);
-  BinaryRead(rStr, optForecast);
   BinaryRead(rStr, dtRain);
   BinaryRead(rStr, startHour);
   BinaryRead(rStr, currentTime);
@@ -635,9 +607,6 @@ void tRunTimer::readRestart(fstream & rStr)
   BinaryRead(rStr, outputInterval);
   BinaryRead(rStr, SPOutputInterval);
   BinaryRead(rStr, RainTime);
-  BinaryRead(rStr, fTime);
-  BinaryRead(rStr, fLength);
-  BinaryRead(rStr, fLead);
   BinaryRead(rStr, etistep);
   BinaryRead(rStr, MetTime);
   BinaryRead(rStr, EtITime);

--- a/src/tSimulator/tRunTimer.h
+++ b/src/tSimulator/tRunTimer.h
@@ -70,9 +70,6 @@ public:
   double  res_hour_begin(int);
   double  res_hour_end(int);
   double  get_abs_hour(double);
-  double  getfTime();
-  double  getfLength();
-  double  getfLead();
   double  getMetTime(int);
   double  getStormTime();
   double  getPrevStormTime();	
@@ -87,7 +84,6 @@ public:
   int     CheckOutputTime();
   int     CheckSpatialOutputTime();
   int     isGaugeTime(double);
-  int     getoptForecast();
 
   void    InitializeTimer( tInputFile &infile );
   void    Start( double, double );
@@ -122,8 +118,6 @@ private:
   double outputInterval; 	// time step for output 
   double SPOutputInterval; 	// time step for spatial output
   double RainTime;  	        // keeps track of rainfall input time
-  int    optForecast;           // Rainfall forecasting option
-  double fTime, fLength, fLead; // Forecasting parameters
   double etistep;               // time step for ET and I comp.
   double MetTime;               // keeps track of met time
   double EtITime;               // keeps track of eti time

--- a/src/tSimulator/tSimul.cpp
+++ b/src/tSimulator/tSimul.cpp
@@ -44,9 +44,6 @@ Simulator::Simulator(SimulationControl *simctrlptr, tRainfall *rainptr,
 	// Time tag of initial time, hour
 	begin_hour = timer->getCurrentTime(); 
 	
-	// For forecasted rainfall, turned off
-	lfr_hour = 0; 
-	
 	// Counter of time, used for GW model
 	GW_label = 0.;
 
@@ -118,11 +115,6 @@ void Simulator::initialize_simulation(tEvapoTrans *EvapoTrans, tSnowPack *SnowPa
 
 	// Prepare rainfall input
 	if (rainIn->rainfallType == 1) {
-		
-		// Check if time for rainfall forecast 
-		if (fmod(timer->getCurrentTime(), timer->getRainDT())==0 &&
-			timer->getoptForecast()!=0)
-			fState = checkForecast();
 		
 		// Compose rainfall file name
 		while ( !(rainIn->Compose_In_Mrain_Name(timer)) ) { 
@@ -260,11 +252,6 @@ void Simulator::simulation_loop(tHydroModel *Moisture, tKinemat *Flow,
       tGraph::resetOverlap();
 #endif
 
-		// End simulation beyond forecast interval
-		if (timer->getoptForecast() != 0 && fState == 3) {
-			break; 
-		}
-
       // Write restart files
       if ( optrestart > 0 && timer->getCurrentTime() == nextRestartDump) {
           writeRestart(restartDir);
@@ -284,7 +271,7 @@ void Simulator::simulation_loop(tHydroModel *Moisture, tKinemat *Flow,
 void Simulator::end_simulation(tKinemat *Flow) 
 { 
 	Flow->getResultsPtr()->
-			writeAndUpdate( timer->getCurrentTime(), 0 );
+			writeAndUpdate( timer->getCurrentTime() );
 	
 	Flow->getResultsPtr()->
 		whenTimeIsOver( timer->getCurrentTime() );
@@ -341,12 +328,7 @@ void Simulator::PrintRunTimeVars(tHydroModel *Moisture, int opt)
 *****************************************************************************/
 void Simulator::UpdatePrecipitationInput()
 {
-	// Check if time for rainfall forecast
-	if (fmod(timer->getCurrentTime(), timer->getRainDT())==0 && 
-		timer->getoptForecast()!=0)
-		fState = checkForecast();
-	
-	// Options for radar or rain gauges 
+	// Options for radar or rain gauges
 	if (rainIn->rainfallType == 1)
 		get_next_mrain(simCtrl->mode);
 	
@@ -616,38 +598,6 @@ void Simulator::get_next_gaugerain()
 	return;
 }
 
-/*****************************************************************************
-**  
-**  Simulator::checkForecast()
-**  
-**  Check the forecast state. Returns integer representing state:
-**  
-**  0 = Before and up to forecast time, Use QPE
-**  1 = In Forecast Period and up to lead time, Use QPF
-**  2 = In Forecast Period and after lead time, Use Average Rainfall
-**  3 = After Forecast Period, End simulation
-**
-*****************************************************************************/
-int Simulator::checkForecast() 
-{
-	int state;
-	
-	if (timer->getCurrentTime() < timer->getfTime())
-		state = 0;
-	else if (timer->getCurrentTime() < (timer->getfTime() + timer->getfLead()) &&
-			 timer->getCurrentTime() >= timer->getfTime())
-		state = 1;
-	else if (timer->getCurrentTime() < (timer->getfTime() + timer->getfLength()) &&
-			 timer->getCurrentTime() >= timer->getfLead())
-		state = 2;
-	else if (timer->getCurrentTime() >= (timer->getfTime() + timer->getfLength()))
-		state = 3;
-	
-	rainIn->setfState(state);
-	
-	return state;
-}
-
 /***************************************************************************
 **
 ** Simulator::writeRestart() Function
@@ -672,9 +622,7 @@ void Simulator::writeRestart(char* directory) const
 
   // Dump local simulator information
   BinaryWrite(rStr, count);
-  BinaryWrite(rStr, fState);
   BinaryWrite(rStr, dt_rain);
-  BinaryWrite(rStr, lfr_hour);
   BinaryWrite(rStr, lmr_hour);
   BinaryWrite(rStr, begin_hour);
   BinaryWrite(rStr, met_hour);
@@ -712,9 +660,7 @@ void Simulator::readRestart(tInputFile &InFl)
 
   // Read local simulator information
   BinaryRead(rStr, count);
-  BinaryRead(rStr, fState);
   BinaryRead(rStr, dt_rain);
-  BinaryRead(rStr, lfr_hour);
   BinaryRead(rStr, lmr_hour);
   BinaryRead(rStr, begin_hour);
   BinaryRead(rStr, met_hour);

--- a/src/tSimulator/tSimul.h
+++ b/src/tSimulator/tSimul.h
@@ -57,9 +57,8 @@ class Simulator
   tCOutput<tCNode>  *outp;        // Pointer to output object
   tRestart<tCNode>  *restart;     // Pointer to restart object
 
-  int count, fState;
-  double dt_rain;                 // Time step of rain 
-  double lfr_hour;                // Time tag of last forecasted rainfall 
+  int count;
+  double dt_rain;                 // Time step of rain
   double lmr_hour;                // Time tag of last measured rainfall 
   double begin_hour;              // Time tag of initial time
   double met_hour;                // Time tag of last measured met
@@ -68,8 +67,6 @@ class Simulator
   
   int searchRain;                 // Search threshold (hours)
 
-
-  int  checkForecast();
 
   void get_next_mrain(int);
   void get_next_met();

--- a/src/utilities/RunsTracker.cpp
+++ b/src/utilities/RunsTracker.cpp
@@ -200,35 +200,6 @@ int main(int argc, char *argv[]){
 	tempo = ReadItem(tempo, "GFLUXOPTION");
 	theOFStream<<"GFLUXOPTION:\t"<<(int)tempo<<endl;
 	
-	theOFStream<<"\n-Forecast Options-"<<endl;
-	BRoption = ReadItem(BRoption, "FORECASTMODE");
-	theOFStream<<"FORECASTMODE:\t";
-	if (BRoption == 0)
-		theOFStream<<"NO FORECAST"<<endl;
-	else if (BRoption == 1)
-		theOFStream<<"QPF"<<endl;
-	else if (BRoption == 2)
-		theOFStream<<"PERSISTENCE"<<endl;
-	else if (BRoption == 3)
-		theOFStream<<"CLIMATOLOGY"<<endl;
-	else
-		theOFStream<<"-- Unknown --"<<endl;
-	if (BRoption >= 1 && BRoption <= 3) {
-		tempo = ReadItem(tempo, "FORECASTTIME");
-		theOFStream<<"FORECASTTIME:    \t"<<tempo<<endl;
-		tempo = ReadItem(tempo, "FORECASTLEADTIME");
-		theOFStream<<"FORECASTLEADTIME:\t"<<tempo<<endl;
-		tempo = ReadItem(tempo, "FORECASTLENGTH");
-		theOFStream<<"FORECASTLENGTH:  \t"<<tempo<<endl;
-		tempo = ReadItem(tempo, "CLIMATOLOGY");
-		theOFStream<<"CLIMATOLOGY:     \t"<<tempo<<endl;
-		BRoption = ReadItem(BRoption, "RAINDISTRIBUTION");
-		theOFStream<<"RAINDISTRIBUTION:\t";
-		if (BRoption == 0)
-			theOFStream<<"SPATIAL"<<endl;
-		else if (BRoption == 1)
-			theOFStream<<"MAP"<<endl;
-	}
 	theOFStream<<endl<<endl;
 	return 0;
 }


### PR DESCRIPTION
This pull request merges changes removing the rainfall forecasting functionality into the dev branch, targeting the upcoming v6.0.0 release.

The primary goal of this update is to remove the `OPTFORECAST` rainfall forecasting feature. The feature allowed mid-run switching between observed and forecast rainfall rasters via a forecast state machine (fState). While functional, this workflow is fully replicated by the existing restart file system, run through the observation period, save a restart, then re-run from restart using forecast rasters as input. The restart-based approach is more flexible (supports ensemble branching, multiple forecast scenarios from a single observed state) and better suited to modern Python-driven forecasting workflows. Removing `OPTFORECAST` simplifies the codebase and eliminates several input keywords that were rarely used in practice.

**Technical Changes (C++ / Inputs)**
* Remove forecast state machine: Forecasting related members removed from `tRainfall`, `tSimulator`, and `tRunTimer`. The `checkForecast()` function (duplicated in both `tSimulator` and `tFlowResults`) and `setfState()` are removed entirely.                
* Simplify rainfall file composition: `Compose_In_Mrain_Name()` in tRainfall now always reads from the observed input path.                                                                                   
* Simplify rainfall assignment: `NewRain(tRunTimer*)` no longer branches on forecast state. The cumulative/average MAP accumulation (used only to support persistence forecast mode) is removed.                                                                                                                                         
* Remove early exit logic: The `fState == 3` early termination in the simulation loop is removed. Simulations now always run to the configured `RUNTIME`.                  
* Update restart format: Forecasting related members removed from the binary restart read/write routines in `tRainfall`, `tSimulator`, `tRunTimer`, and `tFlowResults`. Restart files created with prior versions are not compatible with this release.                                                           
* Remove forecast output column: The `FState_[]` column (previously column 6) is removed from the `.mrf` hydrograph output file. The file now contains 31 columns; columns previously numbered 7–32 are renumbered 6–31.                                                                                                                          
* Remove from preprocessing and run tracking: `FORECASTMODE` and related keywords are removed from `tPreProcess` input validation.
 
**Input/Output Specification**
The following keywords are no longer valid in the main input file and should be removed from existing input files:                                                   
* `FORECASTMODE` - forecast mode selection                                                                                  
* `FORECASTFILE` - path to forecast raster directory                                                                                                  
* `FORECASTTIME` - simulation hour at which forecast period begins                                                                                                       
* `FORECASTLENGTH` - total length of the forecast period                                                                                                        
* `FORECASTLEADTIME` - duration of the QPF lead time                                                                                                           
* `CLIMATOLOGY` - mean areal precipitation climatology value

**Output File Changes**
* *`.mrf` files now contain 31 columns (previously 32). The `FState_[]` column has been removed.
