### PR TITLE
refactor: Standardize Input Data Files

### DIFF
--- a/doc/md/CHANGELOG.md
+++ b/doc/md/CHANGELOG.md
@@ -15,6 +15,7 @@ v6.0.0 is a major release focused on simplifying the user experience and streaml
     * **Phase Partitioning:** Added user-selectable thresholds for Wet-bulb or Air Temperature to determine precipitation phase.
 * **Snow Outputs:** Added `Snow Depth` and `Snow Density` to standard pixel and dynamic output routines. ([#104](https://github.com/tRIBS-Model/tRIBS/pull/104))
 * **Standardized Hydrologic Outputs:** All output files that report hydrologic variables have been standardized to CSV format with a single header line. ([#114](https://github.com/tRIBS-Model/tRIBS/pull/114))
+* **Standardized Hydrologic Inputs:** All forcing and parameter input files were standardized to CSV format with a single header line. Centorid latitude, longitude, and UTC timezone offset are no longer specified in the station and gridded data files. ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
 
 ### Fixed
 * **ET Partitioning:** Fixed a scaling bug in `tEvapoTrans` where unscaled vegetation rates were subtracted from potential ET. ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))
@@ -22,6 +23,7 @@ v6.0.0 is a major release focused on simplifying the user experience and streaml
 * **tIntercept Memory Leak:** Resolved a crash occurring at simulation termination due to improper deallocation of grid filenames when interception was disabled. ([#102](https://github.com/tRIBS-Model/tRIBS/pull/102))
 * **Sub-hourly Precipitation:** Resolved a bug when using sub-hourly precipitation inputs with the snow module turned on caused by the snow module using the wrong timestep. ([#111](https://github.com/tRIBS-Model/tRIBS/pull/111))
 * **Channel Transmission Losses:** Refactored and fixed multiple bugs related to the channel transmission losses. Previous versions capped transmission losses to the available volume of lateral fluxes into the stream node at each timestep. ([#112](https://github.com/tRIBS-Model/tRIBS/pull/112))
+* **Surface Temperature Inputs:** Fixed multiple bugs related to point or gridded surface temperature input. This feature is valuable but was rarely used, now functioning as expected: eahc timestep surface temperature is caluclated using input surface temperature as the initial state. When surface temperature is not provided calculated surface temperature evolves freely from the energy balance (same as before). ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
 
 ### Changed & Refactored
 * **Input Simplification:** Streamlined the `.in` file by removing legacy or unused options including:
@@ -34,18 +36,21 @@ v6.0.0 is a major release focused on simplifying the user experience and streaml
     * Simplified `OPTMESHINPUT` to support only pre-generated 4-mesh files or points files. ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))
     * Simplified `OPTINTERCEPT` to support only the Rutter method for calculating canopy interception. ([#109](https://github.com/tRIBS-Model/tRIBS/pull/109))
     * Removed multiple command line options that were either dead code or neaver used in practice. ([#113](https://github.com/tRIBS-Model/tRIBS/pull/113))
-    * Removed legacy forecat module. ([#115](https://github.com/tRIBS-Model/tRIBS/pull/115))
+    * Removed legacy forecast module. ([#115](https://github.com/tRIBS-Model/tRIBS/pull/115))
 * **C++ Performance Optimizations:** ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))
     * **Memory Management:** Refactored geometry functions (`FindIntersectionCoords`, `PlaneFit`, and `setRVtx`) to pass `tArray<double>` by `const` reference, eliminating massive heap allocation overhead.
     * **Math:** Replaced `pow()` calls with `x*x` and `sqrt()` in core physics loops to reduce CPU cycles.
     * **Standardization:** Unified platform-specific headers and replaced `sprintf` with `snprintf` for modern compiler compatibility.
-* **Error Warning Outputs:** While running the modle in parallel there were many error messages that would be duplicated across all processors or other issues resulting in massive log files. Many error messsages modified to only print 10 times before being silenced. 
+* **Error Warning Outputs:** While running the modle in parallel there were many error messages that would be duplicated across all processors or other issues resulting in massive log files. Many error messsages modified to only print 10 times before being silenced.
+* **Solar Position Calculation Inputs:** Previously the input values for solar position calculations were required in multiple input files. They have been moved to the main input file under the keywords: `UTCOFFSET`, `CENTROIDLAT`, and `CENTROIDLONG`. ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
 
 ### Removed
-* Removed legacy code related to changes in mian input file listed above.
+* Removed legacy code related to changes in main input file listed above.
 * Removed unused platform-specific `#ifdef` blocks in headers. ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))
 * Removed legacy debug printing in `tTriangulator`. ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))
-* Removed legacy command-line flags that were either never used or obsolete. (([#113](https://github.com/tRIBS-Model/tRIBS/pull/113))
+* Removed legacy command-line flags that were either never used or obsolete. ([#113](https://github.com/tRIBS-Model/tRIBS/pull/113))
+* Removed optional humidity inputs. Relative humdity is the only accepted humidity forcing. ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
+* Removed optional `Kpan` parameter for `OPTEVPOTRANS = 2`. Any input ET forcing is now used directly as Potential ET. ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
 
 ---
 

--- a/doc/md/TODO.md
+++ b/doc/md/TODO.md
@@ -6,14 +6,12 @@
 - [ ] Consider flexible approach for specifying outputs, I.E. could we make it so that you could pass in attribute related to a node and have them returned in the dynamic and integrated files. Could also be nice for input parameters, i.e. make list of hard coded parameters and expose as inputs.
 - [ ] Resolve remaing problems in channel transmission losses routine for option 2 & 3, (transient & green-ampt methods) ([#112](https://github.com/tRIBS-Model/tRIBS/pull/112)).
 - [ ] Add root zone depth as land use parameter. If specified to -9999 then use original 1m.
-- [ ] Standardize input text files
 - [ ] Remove default paralleization option
 - [ ] Port MeshBuilder into tRIBS
 - [ ] Package METIS with tRIBS
 - [ ] Merge spatial outputs within tRIBS
 - [ ] Rerun tRIBS through a profiler
 - [ ] Integrate stomatal resistance changes from Becerra branch
-- [ ] Simplify humidity input. Only keep RH an remove others
 - [ ] Generalize restart functionality
 - [ ] Update input timeseries and raster forcing files to use ISO 8601 timestamp format. No chnage to outputs for now, will still be elasped simulation hours. Example from `_MMddYYYYhh.asc` to `_20240615T1200.asc`
 
@@ -32,6 +30,8 @@
 - [x] Simplify ET and interception schemes
 - [x] Improve error output management
 - [x] Clean up channel and hillslope routing parameters
+- [x] Simplify humidity input. Only keep RH an remove others
+- [x] Standardize input text files
 
 
 

--- a/doc/md/TODO.md
+++ b/doc/md/TODO.md
@@ -6,11 +6,11 @@
 - [ ] Consider flexible approach for specifying outputs, I.E. could we make it so that you could pass in attribute related to a node and have them returned in the dynamic and integrated files. Could also be nice for input parameters, i.e. make list of hard coded parameters and expose as inputs.
 - [ ] Resolve remaing problems in channel transmission losses routine for option 2 & 3, (transient & green-ampt methods) ([#112](https://github.com/tRIBS-Model/tRIBS/pull/112)).
 - [ ] Add root zone depth as land use parameter. If specified to -9999 then use original 1m.
-- [ ] Remove default paralleization option
-- [ ] Port MeshBuilder into tRIBS
-- [ ] Package METIS with tRIBS
-- [ ] Merge spatial outputs within tRIBS
-- [ ] Rerun tRIBS through a profiler
+- [ ] Remove default parallelization option
+- [ ] Port MeshBuilder parallelization workflow into tRIBS
+- [ ] Package METIS from parallelization work with tRIBS
+- [ ] Merge spatial outputs from parallel simulations within tRIBS
+- [ ] Rerun tRIBS through a profiler for improving runtimes
 - [ ] Integrate stomatal resistance changes from Becerra branch
 - [ ] Generalize restart functionality
 - [ ] Update input timeseries and raster forcing files to use ISO 8601 timestamp format. No chnage to outputs for now, will still be elasped simulation hours. Example from `_MMddYYYYhh.asc` to `_20240615T1200.asc`
@@ -30,7 +30,7 @@
 - [x] Simplify ET and interception schemes
 - [x] Improve error output management
 - [x] Clean up channel and hillslope routing parameters
-- [x] Simplify humidity input. Only keep RH an remove others
+- [x] Simplify humidity input. Only keep RH and remove others
 - [x] Standardize input text files
 
 

--- a/src/Headers/Inclusions.h
+++ b/src/Headers/Inclusions.h
@@ -25,8 +25,10 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <cassert>
+#include <algorithm>
 #include <memory>
 #include <vector>
 #include <unistd.h>

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -2987,7 +2987,7 @@ void tEvapoTrans::readHydroMetData(int num)
 			     << "(Year,Month,Day,Hour,PA,RH,XC,US,TA,TS_or_IS)." << endl;
 			exit(1);
 		}
-		// tsOption = (headers[9] == "TS") ? 1 : 2;
+		tsOption = (headers[9] == "TS") ? 1 : 2;
 	}
 
 	// Read all data rows

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -2861,6 +2861,7 @@ void tEvapoTrans::readHydroMetStat(char *stationfile)
 	// Validate CSV header: ID,DataFile,Northing,Easting,Elevation
 	std::string headerLine;
 	std::getline(readFile, headerLine);
+	if (!headerLine.empty() && headerLine.back() == '\r') headerLine.pop_back();
 	{
 		std::istringstream hss(headerLine);
 		std::string token;
@@ -2878,6 +2879,7 @@ void tEvapoTrans::readHydroMetStat(char *stationfile)
 	std::vector<std::string> rows;
 	std::string line;
 	while (std::getline(readFile, line)) {
+		if (!line.empty() && line.back() == '\r') line.pop_back();
 		if (!line.empty()) rows.push_back(line);
 	}
 	readFile.close();
@@ -2963,6 +2965,7 @@ void tEvapoTrans::readHydroMetData(int num)
 	// Read CSV header, determine numParams and tsOption
 	std::string headerLine;
 	std::getline(readDataFile, headerLine);
+	if (!headerLine.empty() && headerLine.back() == '\r') headerLine.pop_back();
 	std::vector<std::string> headers;
 	{
 		std::istringstream hss(headerLine);
@@ -2984,13 +2987,14 @@ void tEvapoTrans::readHydroMetData(int num)
 			     << "(Year,Month,Day,Hour,PA,RH,XC,US,TA,TS_or_IS)." << endl;
 			exit(1);
 		}
-		tsOption = (headers[9] == "TS") ? 1 : 2;
+		// tsOption = (headers[9] == "TS") ? 1 : 2;
 	}
 
 	// Read all data rows
 	std::vector<std::string> rows;
 	std::string line;
 	while (std::getline(readDataFile, line)) {
+		if (!line.empty() && line.back() == '\r') line.pop_back();
 		if (!line.empty()) rows.push_back(line);
 	}
 	readDataFile.close();
@@ -3207,6 +3211,7 @@ void tEvapoTrans::readHydroMetGrid(char *gridFile)
 	// Validate CSV header: Variable,BasePath,FileExtension
 	std::string headerLine;
 	std::getline(readFile, headerLine);
+	if (!headerLine.empty() && headerLine.back() == '\r') headerLine.pop_back();
 	{
 		std::istringstream hss(headerLine);
 		std::string token;
@@ -3223,6 +3228,7 @@ void tEvapoTrans::readHydroMetGrid(char *gridFile)
 	std::vector<std::string> rows;
 	std::string line;
 	while (std::getline(readFile, line)) {
+		if (!line.empty() && line.back() == '\r') line.pop_back();
 		if (!line.empty()) rows.push_back(line);
 	}
 	readFile.close();
@@ -3293,6 +3299,7 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 
 	std::string header;
 	std::getline(readFile, header);
+	if (!header.empty() && header.back() == '\r') header.pop_back();
 	int colCount = 1;
 	for (char c : header)
 		if (c == ',') ++colCount;
@@ -3306,6 +3313,8 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 	std::vector<std::vector<std::string>> rows;
 	std::string line;
 	while (std::getline(readFile, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::vector<std::string> row(3);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -699,6 +699,11 @@ void tEvapoTrans::callEvapoPotential()
 	  betaFunc(cNode); 
 	  betaFuncT(cNode);
 	  
+	  // Apply observed surface temperature to node if valid (station path only;
+	  // grid path already sets this via updateVariable before reaching here)
+	  if (metdataOption == 1 && fabs(surfTemp - 9999.99) > 1.0E-3)
+		  cNode->setSurfTemp(surfTemp);
+
 	  // Get Soil/Surface Temperature
 	  Tso = cNode->getSurfTemp() + 273.15;
 	  Tlo = cNode->getSoilTemp() + 273.15;
@@ -2981,13 +2986,12 @@ void tEvapoTrans::readHydroMetData(int num)
 			exit(1);
 		}
 	} else {
-		if (numParams != 10) {
+		if (numParams != 11) {
 			cerr << "\nError: HydroMet data file '" << fileName
-			     << "' header must have exactly 10 columns "
-			     << "(Year,Month,Day,Hour,PA,RH,XC,US,TA,TS_or_IS)." << endl;
+			     << "' header must have exactly 11 columns "
+			     << "(Year,Month,Day,Hour,PA,RH,XC,US,TA,IS,TS)." << endl;
 			exit(1);
 		}
-		tsOption = (headers[9] == "TS") ? 1 : 2;
 	}
 
 	// Read all data rows
@@ -3035,20 +3039,11 @@ void tEvapoTrans::readHydroMetData(int num)
 			tempo = rd(); // TA
 			AirTemperature[count] = (tempo < -50 || tempo > 60) ? 9999.99 : tempo;
 
-			tempo = rd(); // col 9: TS or GlobRad
-			if (fabs(tempo - 9999.99) > 1.0E-3) {
-				if (tsOption == 1) {
-					SurfTemperature[count] = (tempo < -60 || tempo > 70) ? 9999.99 : tempo;
-					GlobRadiation[count] = 9999.99;
-				} else {
-					GlobRadiation[count] = tempo;
-					SurfTemperature[count] = 9999.99;
-				}
-			} else {
-				tsOption = 0;
-				GlobRadiation[count] = 9999.99;
-				SurfTemperature[count] = 9999.99;
-			}
+			tempo = rd(); // col 9: IS (incoming solar, optional: use 9999.99 if not measured)
+			GlobRadiation[count] = (tempo < 0 && fabs(tempo - 9999.99) > 1.0E-3) ? 9999.99 : tempo;
+
+			tempo = rd(); // col 10: TS (surface temperature, optional — use 9999.99 if not measured)
+			SurfTemperature[count] = (fabs(tempo - 9999.99) > 1.0E-3 && (tempo < -60 || tempo > 70)) ? 9999.99 : tempo;
 
 
 			// Timestamp validation
@@ -3423,7 +3418,8 @@ void tEvapoTrans::createVariant()
 				surftemperature = new tVariant(gridPtr,respPtr);
 				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
 					surftemperature->setFileNames(gridBaseNames[ct], gridExtNames[ct]);
-					surftemperature->newVariable(gridParamNames[ct]);}
+					surftemperature->newVariable(gridParamNames[ct]);
+					if (tsOption == 0) tsOption = 1;}
 				else
 					surftemperature->noData(gridParamNames[ct]);
 			}
@@ -3439,7 +3435,8 @@ void tEvapoTrans::createVariant()
 				incomingsolar = new tVariant(gridPtr,respPtr);
 				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
 					incomingsolar->setFileNames(gridBaseNames[ct], gridExtNames[ct]);
-					incomingsolar->newVariable(gridParamNames[ct]);}
+					incomingsolar->newVariable(gridParamNames[ct]);
+					tsOption = 2;}
 				else
 					incomingsolar->noData(gridParamNames[ct]);
 			}
@@ -3647,6 +3644,7 @@ void tEvapoTrans::newHydroMetData(int time)
 				windSpeed = weatherStations[i].getWindSpeed(time);
 				skyCover = weatherStations[i].getSkyCover(time);
 				inShortR = weatherStations[i].getRadGlobal(time);
+				tsOption = (fabs(inShortR - 9999.99) > 1.0E-3) ? 2 : 0;
 
 
 				if (time == 0) {

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -402,7 +402,7 @@ void tEvapoTrans::initializeVariables()
 	SunRisHrLoc=SunSetHrLoc=deltaT=0.0;
 	coeffAl = 0.0; coeffH = 0.0; coeffKt = 0.0;
 	coeffRs = 0.0; coeffKs = 0.0; coeffCs = 0.0; coeffV = 0.0;
-	panEvap = 0.0; coeffPan = 0.0; // Giuseppe June 2012	
+	panEvap = 0.0;
 
 	coeffLAI = 0.0; //RINEHART 2007 @ NMT
 	//Horizon angles
@@ -2620,21 +2620,15 @@ void tEvapoTrans::EvapPenmanMonteith(tCNode* cNode)
 **
 ** EvapPan() Function
 **
-** Calculates actual pan evaporation given the measurements from point
-** locations (treated as Meteorological Stations). Pan coefficient used
-** to correct for artifacts of pan geometry. This coefficient is inputed
-** through the station file otherVariable column. User must use mm/hr
-** for pan evaporation in MDF format.
+** Calculates actual evapotranspiration from measurements at point
+** locations (treated as Meteorological Stations) or from gridded ET.
+** Data must be provided in mm/hr. No pan coefficient is applied;
+** users should apply any pan-to-ET conversion before providing data.
 **
 ***************************************************************************/
-void tEvapoTrans::EvapPan() 
+void tEvapoTrans::EvapPan()
 {
-	if (metdataOption == 1) {
-		potEvap = coeffPan*panEvap;
-	}
-	else if (metdataOption == 2) {
-		potEvap = panEvap;
-	}
+	potEvap = panEvap;
 	
 	// Very approximate: we would need stomatal resistance 
 	// to obtain the transpiration component right
@@ -3808,9 +3802,6 @@ void tEvapoTrans::newHydroMetData(int time)
 			}
 			else {
 				panEvap = weatherStations[i].getPanEvap(time);
-				if (time == 0) {
-					coeffPan = weatherStations[i].getOther();
-				}
 			}
 		}
 	}
@@ -5139,7 +5130,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, coeffV);
   BinaryWrite(rStr, coeffKs);
   BinaryWrite(rStr, coeffCs);
-  BinaryWrite(rStr, coeffPan);
   BinaryWrite(rStr, potEvap);
   BinaryWrite(rStr, actEvap);
   BinaryWrite(rStr, panEvap);
@@ -5301,7 +5291,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
   BinaryRead(rStr, coeffV);
   BinaryRead(rStr, coeffKs);
   BinaryRead(rStr, coeffCs);
-  BinaryRead(rStr, coeffPan);
   BinaryRead(rStr, potEvap);
   BinaryRead(rStr, actEvap);
   BinaryRead(rStr, panEvap);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -53,16 +53,13 @@ tEvapoTrans::tEvapoTrans()
 	LUgridBaseNames = nullptr;
 	LUgridExtNames = nullptr;
 	airpressure = nullptr;
-	dewtemperature = nullptr;
 	skycover = nullptr;
 	windspeed = nullptr;
 	airtemperature = nullptr;
 	surftemperature = nullptr;
-	netradiation = nullptr;
 	incomingsolar = nullptr; //E.R.V. 3/6/2012
 	evapotranspiration = nullptr;
 	relhumidity = nullptr;
-	vaporpressure= nullptr;
 	LandUseAlbGrid = nullptr;
 	ThroughFallGrid = nullptr;
 	VegHeightGrid = nullptr;
@@ -126,16 +123,13 @@ tEvapoTrans::tEvapoTrans(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 	LUgridBaseNames = nullptr;
 	LUgridExtNames = nullptr;
 	airpressure = nullptr;
-	dewtemperature = nullptr;
 	skycover = nullptr;
 	windspeed = nullptr;
 	airtemperature = nullptr;
 	surftemperature = nullptr;
-	netradiation = nullptr;
 	incomingsolar = nullptr; //E.R.V. 3/6/2012
 	evapotranspiration = nullptr;
 	relhumidity = nullptr;
-	vaporpressure = nullptr;
 	LandUseAlbGrid = nullptr;
 	ThroughFallGrid = nullptr;
 	VegHeightGrid = nullptr;
@@ -314,11 +308,9 @@ void tEvapoTrans::CreateHydroMetAndLU(tInputFile &infile)
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);
 		}
-		if (luOption != 0) {
-			latitude  = infile.ReadItem(latitude,  "CENTROIDLAT");
-			longitude = infile.ReadItem(longitude, "CENTROIDLONG");
-			gmt       = infile.ReadItem(gmt,       "UTCOFFSET");
-		}
+		latitude  = infile.ReadItem(latitude,  "CENTROIDLAT");
+		longitude = infile.ReadItem(longitude, "CENTROIDLONG");
+		gmt       = infile.ReadItem(gmt,       "UTCOFFSET");
 	}
 }
 
@@ -339,15 +331,12 @@ void tEvapoTrans::DeleteEvapoTrans()
 		if (metdataOption == 2) {
 			if (evapotransOption != 2) {
 				delete airpressure;
-				delete dewtemperature;
 				delete skycover;
 				delete windspeed;
 				delete airtemperature;
 				delete surftemperature;
-				delete netradiation;
 				delete incomingsolar; //E.R.V. 3/6/2012
 				delete relhumidity;
-				delete vaporpressure;
 				
 				for (int sz=0;sz<nParm;sz++) {
 					delete [] gridParamNames[sz]; //TODO: EXC_BAD_ACCESS (code=1, address=0x0) -WR
@@ -384,7 +373,7 @@ void tEvapoTrans::initializeVariables()
 	
 	airTemp = 0.0; dewTemp = 0.0; surfTemp = 0.0;
 	atmPress = 0.0; windSpeed = 0.0; rHumidity = 0.0;
-	skyCover = 0.0; netRad = 0.0; vPress = 0.0;
+	skyCover = 0.0; vPress = 0.0;
 	latitude = 0.0; longitude = 0.0; gmt = 0;
 	nodeHour = 0; Tso = 0.0; Tlo = 0.0; Gso = 0.0;
 	inLongR = 0.0; outLongR = 0.0; inShortR = 0.0;  
@@ -416,7 +405,7 @@ void tEvapoTrans::initializeVariables()
 	ha3150 = 0.0; ha3375 = 0.0;
 
 	hourlyTimeStep = 0; thisStation = 0; oldTimeStep = 0;
-	tsOption = nrOption = 0;
+	tsOption = 0;
 	
 	currentTime = new int[4];
 	for (int count=0;count<4;count++) {
@@ -446,8 +435,8 @@ void tEvapoTrans::assignStationToNode()
 	
 	for (int ct=0;ct<numStations;ct++) {
 		stationID[ct]   = weatherStations[ct].getStation();
-		stationLong[ct] = weatherStations[ct].getLong(2);
-		stationLat[ct]  = weatherStations[ct].getLat(2);
+		stationLong[ct] = weatherStations[ct].getLong();
+		stationLat[ct]  = weatherStations[ct].getLat();
 	}
 	
 	id_st_tmp = respPtr->doIt(stationID, stationLong, stationLat, numStations); 
@@ -2857,96 +2846,68 @@ void tEvapoTrans::setToNode(tCNode* cNode)
 **                          Set to Zero if not used.
 **
 ***************************************************************************/
-void tEvapoTrans::readHydroMetStat(char *stationfile) 
+void tEvapoTrans::readHydroMetStat(char *stationfile)
 {
-	int nStations, nParams;
-	int Gmt, stationID, numTimes, numParams;
-	double alat, along, rlat, rlong, otherVar;
-	char fileName[kName];
-	//assert(fileName != 0);//WR--09192023: comparison of array 'fileName' not equal to a null pointer is always true
-	
-	Cout<<"\nReading HydroMeteorological Station File '";
-	Cout<< stationfile<<"'..."<<endl<<flush;
-	
-	ifstream readFile(stationfile); 
+	Cout<<"\nReading HydroMeteorological Station File '"
+	    << stationfile <<"'..."<<endl<<flush;
+
+	ifstream readFile(stationfile);
 	if (!readFile) {
 		cout << "File "<<stationfile<<" not found." << endl;
 		cout<<"Exiting Program...\n\n"<<endl;
 		exit(1);
 	}
-	
-	readFile >> nStations;
-	readFile >> nParams;
-	
-	weatherStations = new tHydroMet[nStations];
-	assert(weatherStations != nullptr);
-	
-	numStations = nStations;
-	
-	for (int count=0;count < nStations;count++) {
-		
-		for (int ct=0;ct < nParams;ct++) {
-			if (ct==0) {
-				readFile >> stationID;
-				weatherStations[count].setStation(stationID);
-			}
-			if (ct==1) {
-				readFile >> fileName;
-				weatherStations[count].setFileName(fileName);
-			}
-			if (ct==2) {
-				readFile >> alat;
-				weatherStations[count].setLat(alat,1);
-			}
-			if (ct==3) {
-				readFile >> rlat;
-				if (!readFile) {
-					cout<<"\nError in the SDF File "<<fileName<< " !!"<<endl;
-					cout<<"Please replace BasinLat with Reference Latitude ..."<<endl;
-					cout<<"Exiting Program...\n\n"<<endl;
-					exit(2);
-				}
-				weatherStations[count].setLat(rlat,2);
-			}
-			if (ct==4) {
-				readFile >> along;
-				weatherStations[count].setLong(along,1);
-			}
-			if (ct==5) {
-				readFile >> rlong;
-				if (!readFile) {
-					cout<<"\nError in the SDF File "<<fileName<< " !!"<<endl;
-					cout<<"Please replace BasinLong with Reference Longitude..."<<endl;
-					cout<<"Exiting Program...\n\n"<<endl;
-					exit(3);
-				} 
-				weatherStations[count].setLong(rlong,2);
-			}
-			if (ct==6) {
-				readFile >> Gmt;
-				if (!readFile) {
-					cout<<"\nError in the SDF File "<<fileName<< " !!"<<endl;
-					cout<<"Please replace GMT Tag with GMT Value..."<<endl;
-					cout<<"Exiting Program...\n\n"<<endl;
-					exit(4);
-				}
-				weatherStations[count].setGmt(Gmt);
-			}
-			if (ct==7) {
-				readFile >> numTimes;
-				weatherStations[count].setTime(numTimes);
-			}
-			if (ct==8) {
-				readFile >> numParams;
-				weatherStations[count].setParm(numParams);
-			}
-			if (ct==9) {
-				readFile >> otherVar;
-				weatherStations[count].setOther(otherVar);
-			}
+
+	// Validate CSV header: ID,DataFile,Northing,Easting,Elevation
+	std::string headerLine;
+	std::getline(readFile, headerLine);
+	{
+		std::istringstream hss(headerLine);
+		std::string token;
+		int ncols = 0;
+		while (std::getline(hss, token, ',')) ncols++;
+		if (ncols != 5) {
+			cerr << "\nError: HydroMet station file '" << stationfile
+			     << "' header must have 5 columns "
+			        "(ID,DataFile,Northing,Easting,Elevation)." << endl;
+			exit(1);
 		}
 	}
+
+	// Read all data rows
+	std::vector<std::string> rows;
+	std::string line;
+	while (std::getline(readFile, line)) {
+		if (!line.empty()) rows.push_back(line);
+	}
 	readFile.close();
+
+	numStations = static_cast<int>(rows.size());
+	weatherStations = new tHydroMet[numStations];
+	assert(weatherStations != nullptr);
+
+	for (int count = 0; count < numStations; count++) {
+		std::istringstream ss(rows[count]);
+		std::string token;
+		char fileName[kName];
+
+		std::getline(ss, token, ',');
+		weatherStations[count].setStation(std::stoi(token));
+
+		std::getline(ss, token, ',');
+		strncpy(fileName, token.c_str(), kName - 1);
+		fileName[kName - 1] = '\0';
+		weatherStations[count].setFileName(fileName);
+
+		std::getline(ss, token, ',');
+		weatherStations[count].setLat(std::stod(token));
+
+		std::getline(ss, token, ',');
+		weatherStations[count].setLong(std::stod(token));
+
+		std::getline(ss, token, ',');
+		weatherStations[count].setOther(std::stod(token));
+	}
 }
 
 /***************************************************************************
@@ -2985,273 +2946,167 @@ void tEvapoTrans::readHydroMetStat(char *stationfile)
 **          PanEvaporation (mm/hour) double
 **
 ***************************************************************************/
-void tEvapoTrans::readHydroMetData(int num) 
+void tEvapoTrans::readHydroMetData(int num)
 {
-	int numParams, numTimes;
 	char fileName[kName];
-	char notUsed[10];
-	char paramNames2[10] = {};
-	char paramNames3[10] = {};
-	char *tmpstr;
+	snprintf(fileName, sizeof(fileName), "%s", weatherStations[num].getFileName());
 
-	int *year, *month, *day, *hour;
-	double *AtmPressure, *AirTemperature;
-	double *SkyCover, *WindSpeed, *RelativeHumidity;
-	double *NetRadiation, *SurfTemperature, *PanEvap;
-	double *GlobRadiation;
-	double tempo;
-	
-	tmpstr = weatherStations[num].getFileName();
-    snprintf(fileName,sizeof(fileName),"%s", tmpstr);//WR--09192023: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
-	numParams = weatherStations[num].getParm();
-	numTimes  = weatherStations[num].getTime();
-	
-	Cout<<"\nReading HydroMeteorological Data File '";
-	Cout<<fileName<<"'..."<<endl<<flush;
-	
+	Cout<<"\nReading HydroMeteorological Data File '"<<fileName<<"'..."<<endl<<flush;
+
 	ifstream readDataFile(fileName);
 	if (!readDataFile) {
 		cout << "\nFile " <<fileName<<" not found!" << endl;
 		cout << "Exiting Program...\n\n"<<endl;
-		exit(2);}
-	
-	for (int cnt = 0; cnt<numParams; cnt++) {
-		if (cnt==9)
-			readDataFile >> paramNames2;
-		else if (cnt==10)
-			readDataFile >> paramNames3;
-		else
-			readDataFile >> notUsed;
+		exit(2);
 	}
 
-	if (strcmp(paramNames2,"TS")==0)
-		tsOption = 1;
-	else
-		tsOption = 2;
+	// Read CSV header, determine numParams and tsOption
+	std::string headerLine;
+	std::getline(readDataFile, headerLine);
+	std::vector<std::string> headers;
+	{
+		std::istringstream hss(headerLine);
+		std::string token;
+		while (std::getline(hss, token, ',')) headers.push_back(token);
+	}
+	int numParams = static_cast<int>(headers.size());
 
-	if (strcmp(paramNames3,"NR")==0)
-		nrOption = 1;
-	else
-		nrOption = 2;
-	
-	year  = new int[numTimes];
-	month = new int[numTimes];
-	day   = new int[numTimes];
-	hour  = new int[numTimes];
-	
+	if (evapotransOption == 2) {
+		if (numParams != 5) {
+			cerr << "\nError: ET data file '" << fileName
+			     << "' header must have 5 columns (Year,Month,Day,Hour,ET_mm/hr)." << endl;
+			exit(1);
+		}
+	} else {
+		if (numParams != 10) {
+			cerr << "\nError: HydroMet data file '" << fileName
+			     << "' header must have exactly 10 columns "
+			     << "(Year,Month,Day,Hour,PA,RH,XC,US,TA,TS_or_IS)." << endl;
+			exit(1);
+		}
+		tsOption = (headers[9] == "TS") ? 1 : 2;
+	}
+
+	// Read all data rows
+	std::vector<std::string> rows;
+	std::string line;
+	while (std::getline(readDataFile, line)) {
+		if (!line.empty()) rows.push_back(line);
+	}
+	readDataFile.close();
+
+	int numTimes = static_cast<int>(rows.size());
+	weatherStations[num].setParm(numParams);
+
+	std::vector<int> yr(numTimes), mo(numTimes), dy(numTimes), hr(numTimes);
+
 	if (evapotransOption != 2) {
-		AtmPressure = new double[numTimes];
-		AirTemperature = new double[numTimes];
-		SkyCover = new double[numTimes];
-		WindSpeed = new double[numTimes];
-		RelativeHumidity = new double[numTimes];
-		NetRadiation= new double[numTimes];
-		SurfTemperature = new double[numTimes];
-		GlobRadiation = new double[numTimes];
-		
+		std::vector<double> AtmPressure(numTimes), AirTemperature(numTimes);
+		std::vector<double> SkyCover(numTimes), WindSpeed(numTimes);
+		std::vector<double> RelativeHumidity(numTimes);
+		std::vector<double> SurfTemperature(numTimes), GlobRadiation(numTimes);
+
 		for (int count = 0; count < numTimes; count++) {
-			for (int ct = 0; ct < numParams ;ct++) {
-				if (ct==0) {
-					readDataFile >> year[count];}
-				else if (ct==1) {
-					readDataFile >> month[count];}
-				else if (ct==2) {
-					readDataFile >> day[count];}
-				else if (ct==3) {
-					readDataFile >> hour[count];}
-				
-				else if (ct==4) {
-					readDataFile >> tempo;
-					
-					// SKY2008Snow, AJR2008	
-					// if (tempo < 700 || tempo > 1200)
-					if (tempo < 600 || tempo > 1200)
-					
-						AtmPressure[count] = 9999.99;
-					else 
-						AtmPressure[count] = tempo;
-				}
-				else if (ct==5) {
-					readDataFile >> tempo;
-					RelativeHumidity[count] = (tempo < 0 || tempo > 100) ? 9999.99 : tempo;
-				}
-				else if (ct==6) {
-					readDataFile >> tempo;
-					if (tempo < 0 || tempo > 10)
-						SkyCover[count]= 9999.99;
-					else 
-						SkyCover[count] = tempo;
-				}
-				else if (ct==7) {
-					readDataFile >> tempo;
-					if (tempo < 0 || tempo > 30)
-						WindSpeed[count] = 9999.99;
-					else 
-						WindSpeed[count] = tempo;
-				}
-				else if (ct==8) {
-					readDataFile >> tempo;
-					if (tempo < -50 || tempo > 60)
-						AirTemperature[count] = 9999.99;
-					else 
-						AirTemperature[count] = tempo;
-				}
-				else if (ct==9) {
-					readDataFile >> tempo;
+			std::istringstream ss(rows[count]);
+			std::string token;
+			auto rd = [&]() { std::getline(ss, token, ','); return std::stod(token); };
 
-					// SKY2008Snow, AJR2008
-					if (fabs(tempo-9999.99) > 1.0E-3) { 
+			std::getline(ss, token, ','); yr[count] = std::stoi(token);
+			std::getline(ss, token, ','); mo[count] = std::stoi(token);
+			std::getline(ss, token, ','); dy[count] = std::stoi(token);
+			std::getline(ss, token, ','); hr[count] = std::stoi(token);
 
-						if (tsOption == 1) {
-							if (tempo < -60 || tempo > 70)
-								SurfTemperature[count]= 9999.99;
-							else
-								SurfTemperature[count] = tempo;
-							GlobRadiation[count] = 9999.99;
-						}
-						else {
-							GlobRadiation[count] = tempo;
-							SurfTemperature[count]= 9999.99;
-						}
-					
-					// SKY2008Snow, AJR2008
-					}
-					else {
-						tsOption = 0;
-						GlobRadiation[count] = 9999.99;
-						SurfTemperature[count]= 9999.99;
-					}
+			double tempo = rd(); // PA
+			AtmPressure[count] = (tempo < 600 || tempo > 1200) ? 9999.99 : tempo;
+
+			tempo = rd(); // RH
+			RelativeHumidity[count] = (tempo < 0 || tempo > 100) ? 9999.99 : tempo;
+
+			tempo = rd(); // XC
+			SkyCover[count] = (tempo < 0 || tempo > 10) ? 9999.99 : tempo;
+
+			tempo = rd(); // US
+			WindSpeed[count] = (tempo < 0 || tempo > 30) ? 9999.99 : tempo;
+
+			tempo = rd(); // TA
+			AirTemperature[count] = (tempo < -50 || tempo > 60) ? 9999.99 : tempo;
+
+			tempo = rd(); // col 9: TS or GlobRad
+			if (fabs(tempo - 9999.99) > 1.0E-3) {
+				if (tsOption == 1) {
+					SurfTemperature[count] = (tempo < -60 || tempo > 70) ? 9999.99 : tempo;
+					GlobRadiation[count] = 9999.99;
+				} else {
+					GlobRadiation[count] = tempo;
+					SurfTemperature[count] = 9999.99;
+				}
+			} else {
+				tsOption = 0;
+				GlobRadiation[count] = 9999.99;
+				SurfTemperature[count] = 9999.99;
+			}
 
 
-				}
-				else if (ct==10) {
-					readDataFile >> tempo;
-					if (nrOption == 1) {
-						if (tempo < -1000 || tempo > 1000)
-							NetRadiation[count]= 9999.99;
-						else
-							NetRadiation[count] = tempo;
-					}
-					else
-						NetRadiation[count] = 9999.99;
-				}
-				// If 'numParams' exceeds 11 - for compatability 
-				// with other implementations of tRIBS
-				else 
-					readDataFile >> tempo;
-				
-			} // loop through 'numParams' 
-
-			// Begin block for validation of meteorological data input
-			
-			// After reading all parameters for the current line (at index 'count'),
-			// validate its timestamp.
+			// Timestamp validation
 			if (count == 0) {
-				// Check first timestamp
-				// Assuming getters exist like timer->getStartYear(), etc.
-				// If not, use direct member access like timer->yearS
-				if (year[0] != timer->yearS || month[0] != timer->monthS ||
-					day[0] != timer->dayS   || hour[0] != timer->hourS)
+				if (yr[0] != timer->yearS || mo[0] != timer->monthS ||
+					dy[0] != timer->dayS   || hr[0] != timer->hourS)
 				{
 					std::cerr << "\n\nFATAL ERROR in " << fileName << std::endl;
 					std::cerr << "The first timestamp in the file does not match the simulation start time." << std::endl;
-					std::cerr << "Simulation Start: " << timer->yearS << "/" << timer->monthS 
-							<< "/" << timer->dayS << " " << timer->hourS << ":00" << std::endl;
-					std::cerr << "Found in File:    " << year[0] << "/" << month[0] << "/" << day[0] 
-							<< " " << hour[0] << ":00" << std::endl;
+					std::cerr << "Simulation Start: " << timer->yearS << "/" << timer->monthS
+					          << "/" << timer->dayS << " " << timer->hourS << ":00" << std::endl;
+					std::cerr << "Found in File:    " << yr[0] << "/" << mo[0] << "/" << dy[0]
+					          << " " << hr[0] << ":00" << std::endl;
 					std::cerr << "Exiting Program...\n\n" << std::endl;
 					exit(1);
 				}
 			} else {
-				// Check all subsequent timestamps
-				// Calculate what the expected timestamp should be based on the PREVIOUS line.
-				int expected_yr = year[count-1];
-				int expected_mo = month[count-1];
-				int expected_dy = day[count-1];
-				int expected_hr = hour[count-1];
-				
-				// Add the simulation time step (in hours)
+				int expected_yr = yr[count-1];
+				int expected_mo = mo[count-1];
+				int expected_dy = dy[count-1];
+				int expected_hr = hr[count-1];
 				expected_hr += timer->getEtIStep();
-
-				// Handle time rollovers using the logic adapted from julianDay()
 				while (expected_hr >= 24) {
 					expected_hr -= 24;
 					expected_dy++;
-
-					// Logic adapted directly from julianDay() function
 					int dayInMonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 					bool isLeap = (expected_yr % 4 == 0 && expected_yr % 100 != 0) || (expected_yr % 400 == 0);
-					if (isLeap) {
-						dayInMonth[1] = 29; // February
-					}
-					// Note: C++ arrays are 0-indexed, so use expected_mo - 1
-					int days_in_current_month = dayInMonth[expected_mo - 1];
-
-					if (expected_dy > days_in_current_month) {
+					if (isLeap) dayInMonth[1] = 29;
+					if (expected_dy > dayInMonth[expected_mo - 1]) {
 						expected_dy = 1;
-						expected_mo++;
-						if (expected_mo > 12) {
-							expected_mo = 1;
-							expected_yr++;
-						}
+						if (++expected_mo > 12) { expected_mo = 1; expected_yr++; }
 					}
 				}
-
-				// Compare the calculated expected time with the time read from the file.
-				if (year[count] != expected_yr || month[count] != expected_mo ||
-					day[count] != expected_dy   || hour[count] != expected_hr)
+				if (yr[count] != expected_yr || mo[count] != expected_mo ||
+					dy[count] != expected_dy   || hr[count] != expected_hr)
 				{
 					std::cerr << "\n\nFATAL ERROR in " << fileName << std::endl;
 					std::cerr << "Timestamp gap or duplicate detected in data." << std::endl;
-					std::cerr << "After timestamp: " << year[count-1] << "/" << month[count-1] << "/" << day[count-1] 
-							<< " " << hour[count-1] << ":00" << std::endl;
-					std::cerr << "Expected next timestamp: " << expected_yr << "/" << expected_mo << "/" << expected_dy 
-							<< " " << expected_hr << ":00" << std::endl;
-					std::cerr << "But found in file:       " << year[count] << "/" << month[count] << "/" << day[count] 
-							<< " " << hour[count] << ":00" << std::endl;
+					std::cerr << "After:    " << yr[count-1] << "/" << mo[count-1] << "/" << dy[count-1]
+					          << " " << hr[count-1] << ":00" << std::endl;
+					std::cerr << "Expected: " << expected_yr << "/" << expected_mo << "/" << expected_dy
+					          << " " << expected_hr << ":00" << std::endl;
+					std::cerr << "Found:    " << yr[count] << "/" << mo[count] << "/" << dy[count]
+					          << " " << hr[count] << ":00" << std::endl;
 					std::cerr << "Exiting Program...\n\n" << std::endl;
 					exit(1);
 				}
-			} // End block for validation of meteorological data input
-		}   // loop through 'numTimes'
-	}
-	else {
-		PanEvap = new double[numTimes]; 
-		assert(PanEvap != nullptr);
-		
-		for (int sount = 0;sount<numTimes;sount++) {
-			for (int sct = 0;sct<numParams;sct++) {
-				if (sct==0) {
-					readDataFile >> year[sount];}
-				else if (sct==1) {
-					readDataFile >> month[sount];}
-				else if (sct==2) {
-					readDataFile >> day[sount];}
-				else if (sct==3) {
-					readDataFile >> hour[sount];}
-				else if (sct==4) {
-					readDataFile >> PanEvap[sount];
-				}
 			}
 		}
-	}
-	
-	readDataFile.close();
-	
-	weatherStations[num].setYear(year);
-	weatherStations[num].setMonth(month);
-	weatherStations[num].setDay(day);
-	weatherStations[num].setHour(hour);
-	
-	if (evapotransOption != 2) {
-		robustNess(AirTemperature, numTimes);
-		robustNess(AtmPressure, numTimes);
-		robustNess(SkyCover, numTimes);
-		robustNess(RelativeHumidity, numTimes);
-		robustNess(WindSpeed, numTimes);
-		robustNess(SurfTemperature, numTimes);
-		robustNess(GlobRadiation, numTimes);
 
+		robustNess(AirTemperature.data(), numTimes);
+		robustNess(AtmPressure.data(), numTimes);
+		robustNess(SkyCover.data(), numTimes);
+		robustNess(RelativeHumidity.data(), numTimes);
+		robustNess(WindSpeed.data(), numTimes);
+		robustNess(SurfTemperature.data(), numTimes);
+		robustNess(GlobRadiation.data(), numTimes);
+
+		weatherStations[num].setYear(yr);
+		weatherStations[num].setMonth(mo);
+		weatherStations[num].setDay(dy);
+		weatherStations[num].setHour(hr);
 		weatherStations[num].setAirTemp(AirTemperature);
 		weatherStations[num].setAtmPress(AtmPressure);
 		weatherStations[num].setSkyCover(SkyCover);
@@ -3259,32 +3114,27 @@ void tEvapoTrans::readHydroMetData(int num)
 		weatherStations[num].setWindSpeed(WindSpeed);
 		weatherStations[num].setSurfTemp(SurfTemperature);
 		weatherStations[num].setRadGlobal(GlobRadiation);
-		
-		//cout << "\treadHydroMetData GlobRadiation: " << GlobRadiation<<endl;
-		
-		if (numParams >= 11) {
-			robustNess(NetRadiation, numTimes);
-			weatherStations[num].setNetRad(NetRadiation);
+
+	} else {
+		std::vector<double> PanEvap(numTimes);
+
+		for (int count = 0; count < numTimes; count++) {
+			std::istringstream ss(rows[count]);
+			std::string token;
+			std::getline(ss, token, ','); yr[count] = std::stoi(token);
+			std::getline(ss, token, ','); mo[count] = std::stoi(token);
+			std::getline(ss, token, ','); dy[count] = std::stoi(token);
+			std::getline(ss, token, ','); hr[count] = std::stoi(token);
+			std::getline(ss, token, ','); PanEvap[count] = std::stod(token);
 		}
-		
-		delete [] AtmPressure;
-		delete [] AirTemperature;
-		delete [] RelativeHumidity;
-		delete [] SkyCover;
-		delete [] WindSpeed;
-		delete [] NetRadiation;
-		delete [] SurfTemperature;
-		delete [] GlobRadiation;
-	}
-	else {
-		robustNess(PanEvap, numTimes);
+
+		robustNess(PanEvap.data(), numTimes);
+		weatherStations[num].setYear(yr);
+		weatherStations[num].setMonth(mo);
+		weatherStations[num].setDay(dy);
+		weatherStations[num].setHour(hr);
 		weatherStations[num].setPanEvap(PanEvap);
-		delete[] PanEvap;
 	}
-	delete [] year; 
-	delete [] month; 
-	delete [] day; 
-	delete [] hour;
 }
 
 /***************************************************************************
@@ -3320,60 +3170,84 @@ void tEvapoTrans::robustNess(double *variable, int size)
 **
 ** tEvapoTrans::readHydroMetGrid() Function
 **
-** Reads a file (*.gdf) from HYDROMETGRID keyword containing the base names of 
-** the various input meteorologic parameter grids along with the extension
-** used for the filename. These follow a string that identifies the line
-** with the parameters (ie. PA, TD, XC, US, TA, TS, NR). If no data is
-** available for any parameters, the string NO_DATA should be input 
-** instead of the path name and extension name. In this version, a single
-** value of latitude, longitude and GMT is used for entire grids. The
-** impact of this assumption should be small for small grids.
+** Reads a CSV file (*.gdf) from the HYDROMETGRID keyword containing the base
+** names and extensions of time-varying meteorologic parameter grids. All
+** variables must be listed. Use NO_DATA for both BasePath and FileExtension
+** when a variable is not available (nodes will be assigned 9999.99).
 **
-** Number of parameters 
-** Latitude Longitude GMT
-** ParamName Base Name1 Extension1 (../PATH/parameterName1)
-** ParamName Base Name2  Extension2
-** ...
+** Valid parameter codes (regular ET): PA, RH, XC, US, TA, TS, IS
+** Valid parameter code  (pan ET only): ET
+** Basin centroid lat/long/UTC offset are read from CENTROIDLAT, CENTROIDLONG,
+** and UTCOFFSET keywords in the .in file.
+**
+** CSV format: Variable,BasePath,FileExtension
 ** Example:
-** 3
-** 32.5 -100.3 -6
-** PA ../PATH/PAbase txt
-** TD ../PATH/TDbase txt
-** NR NO_DATA NO_DATA
+** Variable,BasePath,FileExtension
+** PA,/data/grids/pressure,asc
+** RH,/data/grids/humidity,asc
+** XC,NO_DATA,NO_DATA
+** US,/data/grids/wind,asc
+** TA,/data/grids/airtemp,asc
+** TS,NO_DATA,NO_DATA
+** IS,/data/grids/solar,asc
 **
 ***************************************************************************/
-void tEvapoTrans::readHydroMetGrid(char *gridFile) 
+void tEvapoTrans::readHydroMetGrid(char *gridFile)
 {
-	int numParameters;
-	
-	Cout<<"\nReading HydroMeteorological Grid File: "; 
-	Cout<< gridFile<<"..."<<endl<<flush;
-	
-	ifstream readFile(gridFile); 
+	Cout<<"\nReading HydroMeteorological Grid File: "
+	    << gridFile<<"..."<<endl<<flush;
+
+	ifstream readFile(gridFile);
 	if (!readFile) {
 		cout << "\nFile "<<gridFile<<" not found!" << endl;
 		cout << "Exiting Program...\n\n"<<endl;
-		exit(1);}
-	
-	readFile >> numParameters; 
+		exit(1);
+	}
+
+	// Validate CSV header: Variable,BasePath,FileExtension
+	std::string headerLine;
+	std::getline(readFile, headerLine);
+	{
+		std::istringstream hss(headerLine);
+		std::string token;
+		int ncols = 0;
+		while (std::getline(hss, token, ',')) ncols++;
+		if (ncols != 3) {
+			cerr << "\nError: HydroMet grid file '" << gridFile
+			     << "' header must have 3 columns (Variable,BasePath,FileExtension)." << endl;
+			exit(1);
+		}
+	}
+
+	// Count rows
+	std::vector<std::string> rows;
+	std::string line;
+	while (std::getline(readFile, line)) {
+		if (!line.empty()) rows.push_back(line);
+	}
+	readFile.close();
+
+	int numParameters = static_cast<int>(rows.size());
 	nParm = numParameters;
-	readFile >> gridlat;
-	readFile >> gridlong;
-	readFile >> gridgmt;
-	
-	gridBaseNames = new char*[numParameters];
-	gridExtNames = new char*[numParameters];
+	gridBaseNames  = new char*[numParameters];
+	gridExtNames   = new char*[numParameters];
 	gridParamNames = new char*[numParameters];
-	
-	for (int ct=0;ct<numParameters;ct++) {
+
+	for (int ct = 0; ct < numParameters; ct++) {
 		gridParamNames[ct] = new char[10];
-		gridBaseNames[ct] = new char[kName];
-		gridExtNames[ct] = new char[kMaxExt];
-		readFile >> gridParamNames[ct];
-		readFile >> gridBaseNames[ct];
-		readFile >> gridExtNames[ct];
+		gridBaseNames[ct]  = new char[kName];
+		gridExtNames[ct]   = new char[kMaxExt];
+
+		std::istringstream ss(rows[ct]);
+		std::string token;
+		std::getline(ss, token, ',');
+		strncpy(gridParamNames[ct], token.c_str(), 9); gridParamNames[ct][9] = '\0';
+		std::getline(ss, token, ',');
+		strncpy(gridBaseNames[ct], token.c_str(), kName - 1); gridBaseNames[ct][kName - 1] = '\0';
+		std::getline(ss, token, ',');
+		strncpy(gridExtNames[ct], token.c_str(), kMaxExt - 1); gridExtNames[ct][kMaxExt - 1] = '\0';
 	}
-	}
+}
 
 /***************************************************************************
 **
@@ -3512,14 +3386,6 @@ void tEvapoTrans::createVariant()
 				else
 					airpressure->noData(gridParamNames[ct]);
 			}
-			if (strcmp(gridParamNames[ct],"TD")==0) {
-				dewtemperature = new tVariant(gridPtr,respPtr);
-				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
-					dewtemperature->setFileNames(gridBaseNames[ct], gridExtNames[ct]);
-					dewtemperature->newVariable(gridParamNames[ct]);}
-				else
-					dewtemperature->noData(gridParamNames[ct]);
-			}
 			if (strcmp(gridParamNames[ct],"XC")==0) {
 				skycover = new tVariant(gridPtr,respPtr);
 				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
@@ -3552,14 +3418,6 @@ void tEvapoTrans::createVariant()
 				else
 					surftemperature->noData(gridParamNames[ct]);
 			}
-			if (strcmp(gridParamNames[ct],"NR")==0) {
-				netradiation = new tVariant(gridPtr,respPtr);
-				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
-					netradiation->setFileNames(gridBaseNames[ct], gridExtNames[ct]);
-					netradiation->newVariable(gridParamNames[ct]);}
-				else
-					netradiation->noData(gridParamNames[ct]);
-			}
 			if (strcmp(gridParamNames[ct],"RH")==0) {
 				relhumidity = new tVariant(gridPtr,respPtr);
 				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
@@ -3567,14 +3425,6 @@ void tEvapoTrans::createVariant()
 					relhumidity->newVariable(gridParamNames[ct]);}
 				else
 					relhumidity->noData(gridParamNames[ct]);
-			}
-			if (strcmp(gridParamNames[ct],"VP")==0) {
-				vaporpressure = new tVariant(gridPtr,respPtr);
-				if (strcmp(gridBaseNames[ct],"NO_DATA")!=0) {
-					vaporpressure->setFileNames(gridBaseNames[ct], gridExtNames[ct]);
-					vaporpressure->newVariable(gridParamNames[ct]);}
-				else
-					vaporpressure->noData(gridParamNames[ct]);
 			}
 			if (strcmp(gridParamNames[ct],"IS")==0) {  //E.R.V. 3/6/2012
 				incomingsolar = new tVariant(gridPtr,respPtr);
@@ -3789,13 +3639,8 @@ void tEvapoTrans::newHydroMetData(int time)
 				skyCover = weatherStations[i].getSkyCover(time);
 				inShortR = weatherStations[i].getRadGlobal(time);
 
-				if (weatherStations[i].getParm() >= 11)
-					netRad = weatherStations[i].getNetRad(time);
 
 				if (time == 0) {
-					latitude = weatherStations[i].getLat(1);
-					longitude = weatherStations[i].getLong(1);
-					gmt = weatherStations[i].getGmt();
 					Tso = weatherStations[i].getAirTemp(time) + 273.15;
 					Tlo = Tso;
 				}
@@ -3823,14 +3668,10 @@ void tEvapoTrans::newHydroMetGridData(tCNode * cNode) {
 		atmPress = cNode->getAirPressure();
 		windSpeed = cNode->getWindSpeed();
 		skyCover = cNode->getSkyCover();
-		netRad = cNode->getNetRad();
 		inShortR = cNode->getShortRadIn();
 		nodeHour = timer->hour;
 
 		if (timeCount == 0) {
-			latitude = gridlat;
-			longitude = gridlong;
-			gmt = gridgmt;
 			Tso = cNode->getAirTemp() + 273.15;
 			Tlo = Tso;
 		}
@@ -3918,21 +3759,12 @@ void tEvapoTrans::resampleGrids(tRunTimer *t)
 				if (strcmp(gridParamNames[ct],"US")==0) {
 					windspeed->composeFileName(t);
 					windspeed->updateVariable(gridParamNames[ct]);}
-				if (strcmp(gridParamNames[ct],"TD")==0) {
-					dewtemperature->composeFileName(t);
-					dewtemperature->updateVariable(gridParamNames[ct]);}
 				if (strcmp(gridParamNames[ct],"RH")==0) {
 					relhumidity->composeFileName(t);
 					relhumidity->updateVariable(gridParamNames[ct]);}
 				if (strcmp(gridParamNames[ct],"TS")==0) {
 					surftemperature->composeFileName(t);
 					surftemperature->updateVariable(gridParamNames[ct]);}
-				if (strcmp(gridParamNames[ct],"NR")==0) {
-					netradiation->composeFileName(t);
-					netradiation->updateVariable(gridParamNames[ct]);}
-				if (strcmp(gridParamNames[ct],"VP")==0) {
-					vaporpressure->composeFileName(t);
-					vaporpressure->updateVariable(gridParamNames[ct]);}
 				if (strcmp(gridParamNames[ct],"IS")==0) {   //E.R.V 3/6/2012
 					incomingsolar->composeFileName(t);
 					incomingsolar->updateVariable(gridParamNames[ct]);}
@@ -5088,7 +4920,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
 { 
   BinaryWrite(rStr, VerbID);
   BinaryWrite(rStr, tsOption);
-  BinaryWrite(rStr, nrOption);
   BinaryWrite(rStr, Rah);
   BinaryWrite(rStr, Rstm);
   BinaryWrite(rStr, SoilHeatCondTh);
@@ -5107,7 +4938,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, arraySize);
   BinaryWrite(rStr, hourlyTimeStep);
   BinaryWrite(rStr, nParm);
-  BinaryWrite(rStr, gridgmt);
   BinaryWrite(rStr, metdataOption);
   BinaryWrite(rStr, Ioption);
   BinaryWrite(rStr, gFluxOption);
@@ -5121,8 +4951,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
 
   BinaryWrite(rStr, timeStep);
   BinaryWrite(rStr, timeCount);
-  BinaryWrite(rStr, gridlat);
-  BinaryWrite(rStr, gridlong);
   BinaryWrite(rStr, coeffH);
   BinaryWrite(rStr, coeffKt);
   BinaryWrite(rStr, coeffAl);
@@ -5144,7 +4972,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, atmPress);
   BinaryWrite(rStr, windSpeed);
   BinaryWrite(rStr, skyCover);
-  BinaryWrite(rStr, netRad);
   BinaryWrite(rStr, latitude);
   BinaryWrite(rStr, longitude);
   BinaryWrite(rStr, vPress);
@@ -5249,7 +5076,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
 {
   BinaryRead(rStr, VerbID);
   BinaryRead(rStr, tsOption);
-  BinaryRead(rStr, nrOption);
   BinaryRead(rStr, Rah);
   BinaryRead(rStr, Rstm);
   BinaryRead(rStr, SoilHeatCondTh);
@@ -5268,7 +5094,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
   BinaryRead(rStr, arraySize);
   BinaryRead(rStr, hourlyTimeStep);
   BinaryRead(rStr, nParm);
-  BinaryRead(rStr, gridgmt);
   BinaryRead(rStr, metdataOption);
   BinaryRead(rStr, Ioption);
   BinaryRead(rStr, gFluxOption);
@@ -5282,8 +5107,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
 
   BinaryRead(rStr, timeStep);
   BinaryRead(rStr, timeCount);
-  BinaryRead(rStr, gridlat);
-  BinaryRead(rStr, gridlong);
   BinaryRead(rStr, coeffH);
   BinaryRead(rStr, coeffKt);
   BinaryRead(rStr, coeffAl);
@@ -5305,7 +5128,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
   BinaryRead(rStr, atmPress);
   BinaryRead(rStr, windSpeed);
   BinaryRead(rStr, skyCover);
-  BinaryRead(rStr, netRad);
   BinaryRead(rStr, latitude);
   BinaryRead(rStr, longitude);
   BinaryRead(rStr, vPress);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -416,7 +416,7 @@ void tEvapoTrans::initializeVariables()
 	ha3150 = 0.0; ha3375 = 0.0;
 
 	hourlyTimeStep = 0; thisStation = 0; oldTimeStep = 0;
-	vapOption = tsOption = nrOption = 0;
+	tsOption = nrOption = 0;
 	
 	currentTime = new int[4];
 	for (int count=0;count<4;count++) {
@@ -1185,46 +1185,19 @@ double tEvapoTrans::satVaporPress(double toC)
 ** and vice versa, assigns to corrected arrays.
 **
 ***************************************************************************/
-double tEvapoTrans::vaporPress() 
+double tEvapoTrans::vaporPress()
 {
 	double dewTempK;
 	double rv = 461.5;
 	double eo = 6.112;
 	double to = 273.15;
-	
-	if (dewHumFlag == 0) {
-		vPressC = satVaporPress()*rHumidity/100.0;
-		dewTempK = 1.0/((1.0/to) - (log(vPressC/eo)*rv/latentHeat()));
-		dewTempC = dewTempK - 273.15;
-		rHumidityC = rHumidity;
 
-		// AJR2008, SKY2008Snow
-		dewTemp = dewTempC;
-		vPress = vPressC;
-
-	}
-	else if (dewHumFlag == 1) {
-		dewTempK = dewTemp + 273.15;
-		dewTempC = dewTemp;
-		vPressC = eo*exp((latentHeat()/rv)*((1.0/to)-(1.0/dewTempK)));
-		rHumidityC = 100.0*vPressC/satVaporPress();
-		
-		// AJR2008, SKY2008Snow
-		rHumidity = rHumidityC;
-		vPress = vPressC;
-
-	}
-	else if (dewHumFlag == 2) {
-		vPressC = vPress;
-		rHumidityC = 100.0*vPressC/satVaporPress();		
-		dewTempK = 1.0/((1.0/to) - (log(vPressC/eo)*rv/latentHeat()));
-		dewTempC = dewTempK - 273.15;
-
-		// AJR2008, SKY2008Snow
-		rHumidity = rHumidityC;
-		dewTemp = dewTempC;
-
-	}
+	vPressC = satVaporPress()*rHumidity/100.0;
+	dewTempK = 1.0/((1.0/to) - (log(vPressC/eo)*rv/latentHeat()));
+	dewTempC = dewTempK - 273.15;
+	rHumidityC = rHumidity;
+	dewTemp = dewTempC;
+	vPress = vPressC;
 
 	return vPressC;
 }
@@ -2820,19 +2793,8 @@ int tEvapoTrans::getEToption()
 ***************************************************************************/
 void tEvapoTrans::setToNode(tCNode* cNode) 
 { 
-	if (dewHumFlag == 0) {
-		cNode->setDewTemp(dewTempC);
-		cNode->setVapPressure(vPressC);
-	}
-	else if (dewHumFlag == 1) {
-		cNode->setVapPressure(vPressC);
-		cNode->setRelHumid(rHumidityC);
-	}
-	else if (dewHumFlag == 2) {
-		cNode->setDewTemp(dewTempC);
-		cNode->setRelHumid(rHumidityC);
-	}
-	
+	cNode->setDewTemp(dewTempC);
+	cNode->setVapPressure(vPressC);
 	cNode->setPotEvap(potEvap);
 	cNode->setActEvap(actEvap);
 	cNode->setAirTemp(airTemp);
@@ -3013,9 +2975,8 @@ void tEvapoTrans::readHydroMetStat(char *stationfile)
 ** Body Lines:
 **      Values for each parameters. Read in as ints and doubles
 **      Ex. Year (4 digit number), Month, Day, Hour (int)
-**          AtmPressure (mb)  double     
-**          RelativeHumidity (%) double   | either
-**          DewTemperature (C)  double    |   or
+**          AtmPressure (mb)  double
+**          RelativeHumidity (%) double
 **          SkyCover (tenths) double
 **          WindSpeed (m/s) double
 **          AirTemperature (C) double
@@ -3034,15 +2995,14 @@ void tEvapoTrans::readHydroMetData(int num)
 {
 	int numParams, numTimes;
 	char fileName[kName];
-	char paramNames[10] = {};
 	char notUsed[10];
 	char paramNames2[10] = {};
 	char paramNames3[10] = {};
 	char *tmpstr;
-	
+
 	int *year, *month, *day, *hour;
-	double *AtmPressure, *DewTemperature, *AirTemperature;
-	double *SkyCover, *WindSpeed, *RelativeHumidity, *VaporPressure;
+	double *AtmPressure, *AirTemperature;
+	double *SkyCover, *WindSpeed, *RelativeHumidity;
 	double *NetRadiation, *SurfTemperature, *PanEvap;
 	double *GlobRadiation;
 	double tempo;
@@ -3062,24 +3022,14 @@ void tEvapoTrans::readHydroMetData(int num)
 		exit(2);}
 	
 	for (int cnt = 0; cnt<numParams; cnt++) {
-		if (cnt==5)
-			readDataFile >> paramNames; 
-		else if (cnt==9) 
+		if (cnt==9)
 			readDataFile >> paramNames2;
 		else if (cnt==10)
 			readDataFile >> paramNames3;
 		else
 			readDataFile >> notUsed;
 	}
-	
-	// "6th" data element in the input data (air humidity in some form)
-	if (strcmp(paramNames,"RH")==0)
-		vapOption = 1;
-	else if (strcmp(paramNames,"TD")==0)
-		vapOption = 2;
-	else if (strcmp(paramNames,"VP")==0)
-		vapOption = 3;
-	
+
 	if (strcmp(paramNames2,"TS")==0)
 		tsOption = 1;
 	else
@@ -3097,14 +3047,12 @@ void tEvapoTrans::readHydroMetData(int num)
 	
 	if (evapotransOption != 2) {
 		AtmPressure = new double[numTimes];
-		DewTemperature= new double[numTimes];
 		AirTemperature = new double[numTimes];
 		SkyCover = new double[numTimes];
 		WindSpeed = new double[numTimes];
 		RelativeHumidity = new double[numTimes];
 		NetRadiation= new double[numTimes];
 		SurfTemperature = new double[numTimes];
-		VaporPressure = new double[numTimes];
 		GlobRadiation = new double[numTimes];
 		
 		for (int count = 0; count < numTimes; count++) {
@@ -3130,33 +3078,8 @@ void tEvapoTrans::readHydroMetData(int num)
 						AtmPressure[count] = tempo;
 				}
 				else if (ct==5) {
-					if (vapOption == 1) {
-						readDataFile >> tempo;
-						if (tempo < 0 || tempo > 100)
-							RelativeHumidity[count]= 9999.99;
-						else 
-							RelativeHumidity[count] = tempo;
-						DewTemperature[count] = 9999.99;
-						VaporPressure[count] = 9999.99;
-					}
-					else if (vapOption == 2) {
-						readDataFile >> tempo;
-						if (tempo < -50 || tempo > 60)
-							DewTemperature[count] = 9999.99;
-						else 
-							DewTemperature[count] = tempo;
-						RelativeHumidity[count] = 9999.99;
-						VaporPressure[count] = 9999.99;
-					}
-					else if (vapOption == 3) {
-						readDataFile >> tempo;
-						if (tempo < 0  || tempo > 200)
-							VaporPressure[count] = 9999.99;
-						else 
-							VaporPressure[count] = tempo;
-						RelativeHumidity[count] = 9999.99;
-						DewTemperature[count] = 9999.99;
-					}
+					readDataFile >> tempo;
+					RelativeHumidity[count] = (tempo < 0 || tempo > 100) ? 9999.99 : tempo;
 				}
 				else if (ct==6) {
 					readDataFile >> tempo;
@@ -3328,23 +3251,19 @@ void tEvapoTrans::readHydroMetData(int num)
 	
 	if (evapotransOption != 2) {
 		robustNess(AirTemperature, numTimes);
-		robustNess(DewTemperature, numTimes);
 		robustNess(AtmPressure, numTimes);
 		robustNess(SkyCover, numTimes);
 		robustNess(RelativeHumidity, numTimes);
 		robustNess(WindSpeed, numTimes);
 		robustNess(SurfTemperature, numTimes);
-		robustNess(VaporPressure, numTimes);
 		robustNess(GlobRadiation, numTimes);
-		
+
 		weatherStations[num].setAirTemp(AirTemperature);
-		weatherStations[num].setDewTemp(DewTemperature);
 		weatherStations[num].setAtmPress(AtmPressure);
 		weatherStations[num].setSkyCover(SkyCover);
 		weatherStations[num].setRHumidity(RelativeHumidity);
 		weatherStations[num].setWindSpeed(WindSpeed);
 		weatherStations[num].setSurfTemp(SurfTemperature);
-		weatherStations[num].setVaporPress(VaporPressure);
 		weatherStations[num].setRadGlobal(GlobRadiation);
 		
 		//cout << "\treadHydroMetData GlobRadiation: " << GlobRadiation<<endl;
@@ -3354,15 +3273,13 @@ void tEvapoTrans::readHydroMetData(int num)
 			weatherStations[num].setNetRad(NetRadiation);
 		}
 		
-		delete [] AtmPressure; 
-		delete [] DewTemperature; 
+		delete [] AtmPressure;
 		delete [] AirTemperature;
-		delete [] RelativeHumidity; 
+		delete [] RelativeHumidity;
 		delete [] SkyCover;
 		delete [] WindSpeed;
-		delete [] NetRadiation; 
+		delete [] NetRadiation;
 		delete [] SurfTemperature;
-		delete [] VaporPressure;
 		delete [] GlobRadiation;
 	}
 	else {
@@ -3871,41 +3788,22 @@ void tEvapoTrans::newHydroMetData(int time)
 				// SKY2008Snow from AJR2007
 				airTemp += tempLapseRate*(elevation - weatherStations[i].getOther()); //lapse rate added by AJR 2007 @ NMT
 
-				dewTemp = weatherStations[i].getDewTemp(time);
 				surfTemp = weatherStations[i].getSurfTemp(time);
 				rHumidity = weatherStations[i].getRHumidity(time);
-				vPress = weatherStations[i].getVaporPress(time);
 				atmPress = weatherStations[i].getAtmPress(time);
 				windSpeed = weatherStations[i].getWindSpeed(time);
 				skyCover = weatherStations[i].getSkyCover(time);
-                inShortR = weatherStations[i].getRadGlobal(time);
+				inShortR = weatherStations[i].getRadGlobal(time);
 
-				// For run-time checks of input data
-				if (false) {
-					cout<<"\t---> Time = "<<time<<"; Station ID = "<<i<<endl;
-					cout<<"\t---> Tair = "<<airTemp<<"; dewTemp = "<<dewTemp<<";"<<endl;
-					cout<<"\trHumidity = "<<rHumidity<<"; vapPress = "<<vPress<<";"<<endl;
-					cout<<"\tatmPress = "<<atmPress<<"; windSpeed = "<<windSpeed
-						<<"; skyCover = "<<skyCover<<";"<<endl;
-				}
-				
 				if (weatherStations[i].getParm() >= 11)
 					netRad = weatherStations[i].getNetRad(time);
-				
+
 				if (time == 0) {
 					latitude = weatherStations[i].getLat(1);
 					longitude = weatherStations[i].getLong(1);
 					gmt = weatherStations[i].getGmt();
 					Tso = weatherStations[i].getAirTemp(time) + 273.15;
 					Tlo = Tso;
-					
-					//Find the Available Humidity Data
-					if (fabs(dewTemp-9999.99)<1.0E-3 && fabs(vPress-9999.99)<1.0E-3){
-						dewHumFlag = 0;}
-					else if (fabs(rHumidity-9999.99)<1.0E-3 && fabs(vPress-9999.99)<1.0E-3){
-						dewHumFlag = 1;}
-					else if (fabs(rHumidity-9999.99)<1.0E-3 && fabs(dewTemp-9999.99)<1.0E-3){
-						dewHumFlag = 2;} 
 				}
 			}
 			else {
@@ -3929,31 +3827,21 @@ void tEvapoTrans::newHydroMetData(int time)
 void tEvapoTrans::newHydroMetGridData(tCNode * cNode) {   
 	if (evapotransOption != 2) {
 		airTemp = cNode->getAirTemp();
-		dewTemp = cNode->getDewTemp();
 		surfTemp = cNode->getSurfTemp();
 		rHumidity = cNode->getRelHumid();
 		atmPress = cNode->getAirPressure();
 		windSpeed = cNode->getWindSpeed();
 		skyCover = cNode->getSkyCover();
 		netRad = cNode->getNetRad();
-        inShortR = cNode->getShortRadIn(); //E.R.V 3/6/2012
-		vPress = cNode->getVapPressure();
+		inShortR = cNode->getShortRadIn();
 		nodeHour = timer->hour;
 
 		if (timeCount == 0) {
 			latitude = gridlat;
 			longitude = gridlong;
 			gmt = gridgmt;
-			Tso = cNode->getAirTemp() + 273.15; 
-			Tlo = Tso; 
-			
-			//Find the Available Humidity Data
-			if (fabs(dewTemp-9999.99)<1.0E-3 && fabs(vPress-9999.99)<1.0E-3){
-				dewHumFlag = 0;}
-			else if (fabs(rHumidity-9999.99)<1.0E-3 && fabs(vPress-9999.99)<1.0E-3){
-				dewHumFlag = 1;}
-			else if (fabs(rHumidity-9999.99)<1.0E-3 && fabs(dewTemp-9999.99)<1.0E-3) {
-				dewHumFlag = 2;}
+			Tso = cNode->getAirTemp() + 273.15;
+			Tlo = Tso;
 		}
 	}
 	else {
@@ -5208,7 +5096,6 @@ void tEvapoTrans::Debug(int time, int flag)
 void tEvapoTrans::writeRestart(fstream & rStr) const
 { 
   BinaryWrite(rStr, VerbID);
-  BinaryWrite(rStr, vapOption);
   BinaryWrite(rStr, tsOption);
   BinaryWrite(rStr, nrOption);
   BinaryWrite(rStr, Rah);
@@ -5233,7 +5120,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, metdataOption);
   BinaryWrite(rStr, Ioption);
   BinaryWrite(rStr, gFluxOption);
-  BinaryWrite(rStr, dewHumFlag);
   BinaryWrite(rStr, ID);
   BinaryWrite(rStr, gmt);
   BinaryWrite(rStr, nodeHour);
@@ -5372,7 +5258,6 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
 void tEvapoTrans::readRestart(fstream & rStr)
 {
   BinaryRead(rStr, VerbID);
-  BinaryRead(rStr, vapOption);
   BinaryRead(rStr, tsOption);
   BinaryRead(rStr, nrOption);
   BinaryRead(rStr, Rah);
@@ -5397,7 +5282,6 @@ void tEvapoTrans::readRestart(fstream & rStr)
   BinaryRead(rStr, metdataOption);
   BinaryRead(rStr, Ioption);
   BinaryRead(rStr, gFluxOption);
-  BinaryRead(rStr, dewHumFlag);
   BinaryRead(rStr, ID);
   BinaryRead(rStr, gmt);
   BinaryRead(rStr, nodeHour);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -314,6 +314,11 @@ void tEvapoTrans::CreateHydroMetAndLU(tInputFile &infile)
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);
 		}
+		if (luOption != 0) {
+			latitude  = infile.ReadItem(latitude,  "CENTROIDLAT");
+			longitude = infile.ReadItem(longitude, "CENTROIDLONG");
+			gmt       = infile.ReadItem(gmt,       "UTCOFFSET");
+		}
 	}
 }
 
@@ -3489,34 +3494,56 @@ void tEvapoTrans::readHydroMetGrid(char *gridFile)
 ** VH ../PATH/VHbase txt
 **
 ***************************************************************************/
-void tEvapoTrans::readLUGrid(char *gridFile) 
+void tEvapoTrans::readLUGrid(char *gridFile)
 {
-	int numParameters;
-	
-	Cout<<"\nReading Land-Use Data Grid File: "; 
+	Cout<<"\nReading Land-Use Data Grid File: ";
 	Cout<< gridFile<<"..."<<endl<<flush;
-	
-	ifstream readFile(gridFile); 
+
+	ifstream readFile(gridFile);
 	if (!readFile) {
 		cout << "\nFile "<<gridFile<<" not found!" << endl;
 		cout << "Exiting Program...\n\n"<<endl;
-		exit(1);}
-	
-	readFile >> numParameters; 
+		exit(1);
+	}
+
+	std::string header;
+	std::getline(readFile, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != 3) {
+		cout << "\nError: LU grid file '" << gridFile << "' has " << colCount
+		     << " columns, expected 3 (Variable,BasePath,FileExtension)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(1);
+	}
+
+	std::vector<std::vector<std::string>> rows;
+	std::string line;
+	while (std::getline(readFile, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::vector<std::string> row(3);
+		for (int j = 0; j < 3; j++)
+			std::getline(ss, row[j], ',');
+		rows.push_back(row);
+	}
+	readFile.close();
+
+	int numParameters = static_cast<int>(rows.size());
 	nParmLU = numParameters;
-	readFile >> LUgridlat;
-	readFile >> LUgridlong;
-	readFile >> LUgridgmt;
 
 	LUgridBaseNames = new char*[numParameters];
 	LUgridExtNames = new char*[numParameters];
 	LUgridParamNames = new char*[numParameters];
-	
+
 	for (int ct=0;ct<numParameters;ct++) {
 		LUgridParamNames[ct] = new char[kMaxExt];
 		LUgridBaseNames[ct] = new char[kName];
 		LUgridExtNames[ct] = new char[kMaxExt];
-		readFile >> LUgridParamNames[ct];
+
+		strncpy(LUgridParamNames[ct], rows[ct][0].c_str(), kMaxExt - 1);
+		LUgridParamNames[ct][kMaxExt - 1] = '\0';
 
 		if ( (strcmp(LUgridParamNames[ct],"AL")!=0) &&
 				(strcmp(LUgridParamNames[ct],"TF")!=0) &&
@@ -3528,18 +3555,17 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 		  		(strcmp(LUgridParamNames[ct],"DE")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"OT")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"LA")!=0) &&
-                (strcmp(LUgridParamNames[ct],"SE")!=0) && // CJC2025
-                (strcmp(LUgridParamNames[ct],"ST")!=0) ) { // CJC2025
-			
+                (strcmp(LUgridParamNames[ct],"SE")!=0) &&
+                (strcmp(LUgridParamNames[ct],"ST")!=0) ) {
 			Cout << "\nA land use parameter name in the LU gdf file is an unexpected one."<<endl;
 			Cout << "\nExpected variables: AL,TF,VH,SR,VF,CC,DC,DE,OT,LA,SE or ST" << endl;
 			Cout << "\tCheck and re-run the program" << endl;
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);
-
 		}
 
-		readFile >> LUgridBaseNames[ct];
+		strncpy(LUgridBaseNames[ct], rows[ct][1].c_str(), kName - 1);
+		LUgridBaseNames[ct][kName - 1] = '\0';
 
 		if (strcmp(LUgridBaseNames[ct],"NO_DATA")==0) {
 			Cout << "\nCannot use NO_DATA for LU Grids"<<endl;
@@ -3547,9 +3573,10 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 			exit(1);
 		}
 
-		readFile >> LUgridExtNames[ct];
+		strncpy(LUgridExtNames[ct], rows[ct][2].c_str(), kMaxExt - 1);
+		LUgridExtNames[ct][kMaxExt - 1] = '\0';
 	}
-	}
+}
 
 /***************************************************************************
 **
@@ -3986,12 +4013,6 @@ void tEvapoTrans::newLUGridData(tCNode * cNode)
 		}
 	}
 
-	if (IfNotFirstTStepLU == 0) { // modified from correction by SY, TM: 11/19/07
-		latitude = LUgridlat;
-		longitude = LUgridlong;
-		gmt = LUgridgmt;
-		IfNotFirstTStepLU = 1;
-	}
 
 	}
 
@@ -5286,16 +5307,12 @@ void tEvapoTrans::writeRestart(fstream & rStr) const
 
   BinaryWrite(rStr, snowOption); // Snow and Shelter
   BinaryWrite(rStr, shelterOption);
-  BinaryWrite(rStr, LUgridgmt);
   BinaryWrite(rStr, luOption);
   BinaryWrite(rStr, nParmLU);
   BinaryWrite(rStr, luInterpOption);
-  BinaryWrite(rStr, IfNotFirstTStepLU);
-  BinaryWrite(rStr, metHour); 
-  BinaryWrite(rStr, etHour); 
+  BinaryWrite(rStr, metHour);
+  BinaryWrite(rStr, etHour);
   BinaryWrite(rStr, rainInt);
-  BinaryWrite(rStr, LUgridlat); 
-  BinaryWrite(rStr, LUgridlong);
   BinaryWrite(rStr, coeffLAI);
   BinaryWrite(rStr, shelterFactorGlobal); 
   BinaryWrite(rStr, landRefGlobal);
@@ -5454,16 +5471,12 @@ void tEvapoTrans::readRestart(fstream & rStr)
 
   BinaryRead(rStr, snowOption); // Snow and Shelter
   BinaryRead(rStr, shelterOption);
-  BinaryRead(rStr, LUgridgmt);
   BinaryRead(rStr, luOption);
   BinaryRead(rStr, nParmLU);
   BinaryRead(rStr, luInterpOption);
-  BinaryRead(rStr, IfNotFirstTStepLU);
   BinaryRead(rStr, metHour);
   BinaryRead(rStr, etHour);
   BinaryRead(rStr, rainInt);
-  BinaryRead(rStr, LUgridlat);
-  BinaryRead(rStr, LUgridlong);
   BinaryRead(rStr, coeffLAI);
   BinaryRead(rStr, shelterFactorGlobal);
   BinaryRead(rStr, landRefGlobal);

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -110,7 +110,6 @@ class tEvapoTrans
   double getinShortWave() const;
   double getinLongWave() const;
   double getoutLongWave() const;
-  double getNetRad() const;
   double getDeltaT() const;
   double getSunRiseHour() const;
   double getSunSetHour() const;
@@ -147,13 +146,13 @@ class tEvapoTrans
   int shelterOption{}; // NEW FOR SHELTERING... SKY2008Snow from AJR2007
   int gFluxOption{}, ID{};
   int gmt{}, nodeHour{}, thisStation{}, oldTimeStep{};
-  int numStations{}, arraySize{}, hourlyTimeStep{}, nParm{}, gridgmt{};
-  int tsOption{}, nrOption{};
+  int numStations{}, arraySize{}, hourlyTimeStep{}, nParm{};
+  int tsOption{};
   int luOption{}, nParmLU;  //SKYnGM2008LU: added by AJR 2007
   int luInterpOption{};  //SKYnGM2008LU
   int timeCount;
 
-  double timeStep{}, gridlat{}, gridlong{};
+  double timeStep{};
   double metHour{}, etHour{}, rainInt{}; // SKY2008Snow from AJR2007
 
   double coeffH{}, coeffKt{}, coeffAl{}, coeffRs{}, coeffV{};
@@ -165,7 +164,7 @@ class tEvapoTrans
   double potEvap{}, actEvap{}, panEvap{}, betaS{}, betaT{};
   double airTemp{}, dewTemp{}, surfTemp{}, Tso{}, Tlo{};
   double rHumidity{}, atmPress{}, windSpeed{}, skyCover{};
-  double netRad{}, latitude{}, longitude{}, vPress{};
+  double latitude{}, longitude{}, vPress{};
   double inLongR{}, inShortR{}, outLongR{};
   double Tlinke{};
   double Is{}, Ic{}, Ics{}, Id{}, Ids{};
@@ -199,9 +198,9 @@ class tEvapoTrans
   char **gridParamNames, **gridBaseNames, **gridExtNames;
   char **LUgridParamNames, **LUgridBaseNames, **LUgridExtNames; // SKYnGM2008LU: added by AJR 2007
 
-  tVariant *airpressure, *dewtemperature, *skycover, *windspeed;
-  tVariant *airtemperature, *surftemperature, *netradiation, *incomingsolar; //E.R.V 3/6/2012
-  tVariant *evapotranspiration, *relhumidity, *vaporpressure;
+  tVariant *airpressure, *skycover, *windspeed;
+  tVariant *airtemperature, *surftemperature, *incomingsolar; //E.R.V 3/6/2012
+  tVariant *evapotranspiration, *relhumidity;
 
   // SKYnGM2008LU: added by AJR 2007
   tVariant *LandUseAlbGrid, *ThroughFallGrid, *VegHeightGrid; 
@@ -245,7 +244,6 @@ inline double tEvapoTrans::getTauAngle()    const {return tau;}
 inline double tEvapoTrans::getinShortWave() const {return inShortR;}
 inline double tEvapoTrans::getinLongWave()  const {return inLongR;}
 inline double tEvapoTrans::getoutLongWave() const {return outLongR;}
-inline double tEvapoTrans::getNetRad()      const {return netRad;}
 
 
 #endif

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -145,10 +145,10 @@ class tEvapoTrans
   int evapotransOption{}, metdataOption{}, Ioption{};
   int snowOption{}; // NEW FOR SNOW.... SKY2008Snow from AJR2007
   int shelterOption{}; // NEW FOR SHELTERING... SKY2008Snow from AJR2007
-  int gFluxOption{}, dewHumFlag{}, ID{};
+  int gFluxOption{}, ID{};
   int gmt{}, nodeHour{}, thisStation{}, oldTimeStep{};
   int numStations{}, arraySize{}, hourlyTimeStep{}, nParm{}, gridgmt{};
-  int vapOption{}, tsOption{}, nrOption{};
+  int tsOption{}, nrOption{};
   int luOption{}, nParmLU;  //SKYnGM2008LU: added by AJR 2007
   int luInterpOption{};  //SKYnGM2008LU
   int timeCount;

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -157,7 +157,7 @@ class tEvapoTrans
   double metHour{}, etHour{}, rainInt{}; // SKY2008Snow from AJR2007
 
   double coeffH{}, coeffKt{}, coeffAl{}, coeffRs{}, coeffV{};
-  double coeffKs{}, coeffCs{}, coeffPan{};
+  double coeffKs{}, coeffCs{};
   // SKY2008Snow from AJR2007
   double coeffLAI{};
   double Rah{}, Rstm{};

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -148,16 +148,13 @@ class tEvapoTrans
   int gFluxOption{}, dewHumFlag{}, ID{};
   int gmt{}, nodeHour{}, thisStation{}, oldTimeStep{};
   int numStations{}, arraySize{}, hourlyTimeStep{}, nParm{}, gridgmt{};
-  int LUgridgmt{}; //SKYnGM2008LU: added by AJR 2007
   int vapOption{}, tsOption{}, nrOption{};
   int luOption{}, nParmLU;  //SKYnGM2008LU: added by AJR 2007
   int luInterpOption{};  //SKYnGM2008LU
   int timeCount;
 
   double timeStep{}, gridlat{}, gridlong{};
-  double IfNotFirstTStepLU{}; //SKYnGM2008LU: added by AJR 2007
   double metHour{}, etHour{}, rainInt{}; // SKY2008Snow from AJR2007
-  double LUgridlat{}, LUgridlong{}; //SKYnGM2008LU: added by AJR 2007
 
   double coeffH{}, coeffKt{}, coeffAl{}, coeffRs{}, coeffV{};
   double coeffKs{}, coeffCs{}, coeffPan{};

--- a/src/tHydro/tHydroMet.cpp
+++ b/src/tHydro/tHydroMet.cpp
@@ -24,51 +24,15 @@
 //=========================================================================
 tHydroMet::tHydroMet()
 {
-	numTimes = 0;
 	numParams = 0;
-	gmt = 0;
 	stationID = 0;
-	latitude = 0.0;
-	longitude = 0.0;
 	basinLong = 0.0;
 	basinLat = 0.0;
 	otherVariable = 0.0;
 	meanTemp = 0.0;
 }
 
-tHydroMet::~tHydroMet()
-{
-	if (numTimes > 0 ) { 
-		delete [] year;
-		delete [] month;
-		delete [] day;
-		delete [] hour;
-		
-		// BUG fixed by Giuseppe Mascaro to allow safe deleting when
-		// using PAN stations - June 2012
-		if (numParams == 5) {
-			
-			if (panEvap){
-				delete [] panEvap;
-			}
-		}
-		else {
-			if (airTemp){
-				delete [] airTemp;
-				delete [] surfTemp;
-				delete [] rHumidity;
-				delete [] skyCover;
-				delete [] windSpeed;
-				delete [] atmPress;
-				delete [] RadGlobal;
-			}
-			if (numParams >= 11) {
-				delete [] netRad;
-			}
-		}
-		// END of BUG Fixed by Giuseppe Mascaro - June 2012
-	}
-}
+tHydroMet::~tHydroMet() = default;
 
 //=========================================================================
 //
@@ -80,7 +44,7 @@ tHydroMet::~tHydroMet()
 
 /***************************************************************************
 **
-** Set() and Get() Functions for Station Indentifiers
+** Set() and Get() Functions for Station Identifiers
 **
 ***************************************************************************/
 
@@ -92,48 +56,24 @@ int tHydroMet::getStation(){
 	return stationID;
 }
 
-void tHydroMet::setLat(double lat, int option){
-	if(option == 1)
-		latitude = lat;
-	else
-		basinLat = lat;
+void tHydroMet::setLat(double lat){
+	basinLat = lat;
 }
 
-double tHydroMet::getLat(int option){
-	if(option==1)
-		return latitude;
-	else 
-		return basinLat;
+double tHydroMet::getLat(){
+	return basinLat;
 }
 
-void tHydroMet::setLong(double longit, int option){
-	if(option == 1)
-		longitude = longit;
-	else
-		basinLong = longit;
+void tHydroMet::setLong(double longit){
+	basinLong = longit;
 }
 
-double tHydroMet::getLong(int option){
-	if(option == 1)
-		return longitude;
-	else
-		return basinLong;
+double tHydroMet::getLong(){
+	return basinLong;
 }
 
-void tHydroMet::setGmt(int gmtime){
-	gmt = gmtime;
-}
-
-int tHydroMet::getGmt(){
-	return gmt;
-}
-
-void tHydroMet::setTime(int time){
-	numTimes = time;
-}
-
-int tHydroMet::getTime(){
-	return numTimes;
+int tHydroMet::getTime() const {
+	return static_cast<int>(year.size());
 }
 
 void tHydroMet::setParm(int parm){
@@ -153,7 +93,7 @@ double tHydroMet::getOther(){
 }
 
 void tHydroMet::setFileName(char* file){
-	snprintf(fileName,sizeof(fileName),"%s", file);//WR--09192023: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
+	snprintf(fileName, sizeof(fileName), "%s", file);
 }
 
 char* tHydroMet::getFileName(){
@@ -167,230 +107,154 @@ char* tHydroMet::getFileName(){
 **
 ***************************************************************************/
 
-void tHydroMet::setYear(int *syear){ 
-	year = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		year[ct] = syear[ct]; 
-	}
+void tHydroMet::setYear(const std::vector<int> &v){
+	year = v;
 }
 
-int* tHydroMet::getYear(){
-	return year;
-}
-
-int tHydroMet::getYear(int time){
+int tHydroMet::getYear(int time) const {
 	return year[time];
 }
 
-void tHydroMet::setMonth(int *smonth){
-	month = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		month[ct] = smonth[ct];
-	}
+void tHydroMet::setMonth(const std::vector<int> &v){
+	month = v;
 }
 
-int* tHydroMet::getMonth(){
-	return month;
-}
-
-int tHydroMet::getMonth(int time){
+int tHydroMet::getMonth(int time) const {
 	return month[time];
 }
 
-void tHydroMet::setDay(int *sday){
-	day = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		day[ct] = sday[ct];
-	}
+void tHydroMet::setDay(const std::vector<int> &v){
+	day = v;
 }
 
-int* tHydroMet::getDay(){
-	return day;
-}
-
-int tHydroMet::getDay(int time){
+int tHydroMet::getDay(int time) const {
 	return day[time];
 }
 
-
-void tHydroMet::setHour(int *shour){
-	hour = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		hour[ct] = shour[ct];
-	}
+void tHydroMet::setHour(const std::vector<int> &v){
+	hour = v;
 }
 
-int* tHydroMet::getHour(){
-	return hour;
-}
-
-int tHydroMet::getHour(int time){
+int tHydroMet::getHour(int time) const {
 	return hour[time];
 }
 
-void tHydroMet::setAirTemp(double *air){
-	int count = 0; 
-	airTemp = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		meanTemp += air[ct];
-		airTemp[ct] = air[ct];
-		count++;
-	}
-	meanTemp = meanTemp/count;
+void tHydroMet::setAirTemp(const std::vector<double> &v){
+	int count = 0;
+	meanTemp = 0.0;
+	airTemp = v;
+	for (double val : v) { meanTemp += val; count++; }
+	if (count > 0) meanTemp /= count;
 }
 
-double tHydroMet::getAirTemp(int time){
-    return airTemp[time];
+double tHydroMet::getAirTemp(int time) const {
+	return airTemp[time];
 }
 
 double tHydroMet::getMeanTemp(){
 	return meanTemp;
 }
 
-void tHydroMet::setSurfTemp(double *surf){
-	surfTemp = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		surfTemp[ct] = surf[ct];
-	}
+void tHydroMet::setSurfTemp(const std::vector<double> &v){
+	surfTemp = v;
 }
 
-double tHydroMet::getSurfTemp(int time){
+double tHydroMet::getSurfTemp(int time) const {
 	return surfTemp[time];
 }
 
-void tHydroMet::setAtmPress(double *atm){
-	atmPress = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		atmPress[ct] = atm[ct];
-	}
+void tHydroMet::setAtmPress(const std::vector<double> &v){
+	atmPress = v;
 }
 
-double tHydroMet::getAtmPress(int time){
+double tHydroMet::getAtmPress(int time) const {
 	return atmPress[time];
 }
 
-void tHydroMet::setSkyCover(double *sky){
-	skyCover = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		skyCover[ct]= sky[ct];
-	}
+void tHydroMet::setSkyCover(const std::vector<double> &v){
+	skyCover = v;
 }
 
-double tHydroMet::getSkyCover(int time){
+double tHydroMet::getSkyCover(int time) const {
 	return skyCover[time];
 }
 
-void tHydroMet::setRHumidity(double *rh){
-	rHumidity = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		rHumidity[ct] = rh[ct];
-	}
+void tHydroMet::setRHumidity(const std::vector<double> &v){
+	rHumidity = v;
 }
 
-double tHydroMet::getRHumidity(int time){
+double tHydroMet::getRHumidity(int time) const {
 	return rHumidity[time];
 }
 
-
-void tHydroMet::setWindSpeed(double *wind){
-	windSpeed = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		windSpeed[ct] = wind[ct];
-	}
+void tHydroMet::setWindSpeed(const std::vector<double> &v){
+	windSpeed = v;
 }
 
-double tHydroMet::getWindSpeed(int time){
+double tHydroMet::getWindSpeed(int time) const {
 	return windSpeed[time];
 }
 
-void tHydroMet::setNetRad(double *nrad){
-	netRad = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		netRad[ct] = nrad[ct];
-	}
+void tHydroMet::setPanEvap(const std::vector<double> &v){
+	panEvap = v;
 }
 
-double tHydroMet::getNetRad(int time){
-	return netRad[time];
-}
-
-void tHydroMet::setPanEvap(double *panE){
-	panEvap = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		panEvap[ct] = panE[ct];
-	}
-}
-
-double tHydroMet::getPanEvap(int time){
+double tHydroMet::getPanEvap(int time) const {
 	return panEvap[time];
 }
 
-void tHydroMet::setRadGlobal(double *rad){
-	RadGlobal = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		RadGlobal[ct] = rad[ct];
-	}
+void tHydroMet::setRadGlobal(const std::vector<double> &v){
+	RadGlobal = v;
 }
 
-double tHydroMet::getRadGlobal(int time){
+double tHydroMet::getRadGlobal(int time) const {
 	return RadGlobal[time];
 }
 
-void tHydroMet::setRadDirect(double *rad){
-	RadDirect = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		RadDirect[ct] = rad[ct];
-	}
+void tHydroMet::setRadDirect(const std::vector<double> &v){
+	RadDirect = v;
 }
 
-double tHydroMet::getRadDirect(int time){
+double tHydroMet::getRadDirect(int time) const {
 	return RadDirect[time];
 }
 
-void tHydroMet::setRadDiffuse(double *rad){
-	RadDiffuse = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		RadDiffuse[ct] = rad[ct];
-	}
+void tHydroMet::setRadDiffuse(const std::vector<double> &v){
+	RadDiffuse = v;
 }
 
-double tHydroMet::getRadDiffuse(int time){
+double tHydroMet::getRadDiffuse(int time) const {
 	return RadDiffuse[time];
 }
 
-void tHydroMet::setRainMet(double *rain){
-	RainMet = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		RainMet[ct] = rain[ct];
-	}
+void tHydroMet::setRainMet(const std::vector<double> &v){
+	RainMet = v;
 }
 
-double tHydroMet::getRainMet(int time){
+double tHydroMet::getRainMet(int time) const {
 	return RainMet[time];
 }
 
 /***************************************************************************
 **
 ** tHydroMet::writeRestart() Function
-** 
+**
 ** Called from tSimulator during simulation loop
-** 
+**
 ***************************************************************************/
-                                                                            
+
 void tHydroMet::writeRestart(fstream & rStr) const
 {
-  BinaryWrite(rStr, numTimes);
+  int sz = static_cast<int>(year.size());
+  BinaryWrite(rStr, sz);
   BinaryWrite(rStr, numParams);
-  BinaryWrite(rStr, gmt);
   BinaryWrite(rStr, stationID);
-  BinaryWrite(rStr, latitude);
-  BinaryWrite(rStr, longitude);
   BinaryWrite(rStr, basinLat);
   BinaryWrite(rStr, basinLong);
   BinaryWrite(rStr, otherVariable);
   BinaryWrite(rStr, meanTemp);
-  for (int i = 0; i < numTimes; i++) {
-    BinaryWrite(rStr, year[i]); 
+  for (int i = 0; i < sz; i++) {
+    BinaryWrite(rStr, year[i]);
     BinaryWrite(rStr, month[i]);
     BinaryWrite(rStr, day[i]);
     BinaryWrite(rStr, hour[i]);
@@ -398,24 +262,20 @@ void tHydroMet::writeRestart(fstream & rStr) const
 	// Giuseppe DEBUG Restart 2012 - START 
 	// I have introduced an IF and ELSE to deal with the case
 	// of PAN ET data
-	if (numParams == 5){		
-		for (int i = 0; i < numTimes; i++) {
-			BinaryWrite(rStr, panEvap[i]);		
-		}
-	}
-	else {// Giuseppe DEBUG Restart 2012 - END	
-		for (int i = 0; i < numTimes; i++) {
-			BinaryWrite(rStr, airTemp[i]);
-			BinaryWrite(rStr, surfTemp[i]);
-			BinaryWrite(rStr, rHumidity[i]);
-			BinaryWrite(rStr, skyCover[i]);
-			BinaryWrite(rStr, windSpeed[i]);
-			BinaryWrite(rStr, atmPress[i]);
-			BinaryWrite(rStr, RadGlobal[i]);
-			if (numParams >= 11)
-				BinaryWrite(rStr, netRad[i]);
-		}
-	}
+  if (numParams == 5) {
+    for (int i = 0; i < sz; i++)
+      BinaryWrite(rStr, panEvap[i]);
+  } else {// Giuseppe DEBUG Restart 2012 - END	
+    for (int i = 0; i < sz; i++) {
+      BinaryWrite(rStr, airTemp[i]);
+      BinaryWrite(rStr, surfTemp[i]);
+      BinaryWrite(rStr, rHumidity[i]);
+      BinaryWrite(rStr, skyCover[i]);
+      BinaryWrite(rStr, windSpeed[i]);
+      BinaryWrite(rStr, atmPress[i]);
+      BinaryWrite(rStr, RadGlobal[i]);
+    }
+  }
 }
 
 /***************************************************************************
@@ -426,17 +286,17 @@ void tHydroMet::writeRestart(fstream & rStr) const
 
 void tHydroMet::readRestart(fstream & rStr)
 {
-  BinaryRead(rStr, numTimes);
+  int sz = 0;
+  BinaryRead(rStr, sz);
   BinaryRead(rStr, numParams);
-  BinaryRead(rStr, gmt);
   BinaryRead(rStr, stationID);
-  BinaryRead(rStr, latitude);
-  BinaryRead(rStr, longitude);
   BinaryRead(rStr, basinLat);
   BinaryRead(rStr, basinLong);
   BinaryRead(rStr, otherVariable);
   BinaryRead(rStr, meanTemp);
-  for (int i = 0; i < numTimes; i++) {
+
+  year.resize(sz); month.resize(sz); day.resize(sz); hour.resize(sz);
+  for (int i = 0; i < sz; i++) {
     BinaryRead(rStr, year[i]);
     BinaryRead(rStr, month[i]);
     BinaryRead(rStr, day[i]);
@@ -445,23 +305,23 @@ void tHydroMet::readRestart(fstream & rStr)
 	// Giuseppe DEBUG Restart 2012 - START 
 	// I have introduced an IF and ELSE to deal with the case
 	// of PAN ET data
-	if (numParams == 5){		
-	for (int i = 0; i < numTimes; i++) {
-		BinaryRead(rStr, panEvap[i]);		
-	}
-  }
-  else {// Giuseppe DEBUG Restart 2012 - END	
-	  for (int i = 0; i < numTimes; i++) {
-		  BinaryRead(rStr, airTemp[i]);
-		  BinaryRead(rStr, surfTemp[i]);
-		  BinaryRead(rStr, rHumidity[i]);
-		  BinaryRead(rStr, skyCover[i]);
-		  BinaryRead(rStr, windSpeed[i]);
-		  BinaryRead(rStr, atmPress[i]);
-		  BinaryRead(rStr, RadGlobal[i]);
-		  if (numParams >= 11)
-			  BinaryRead(rStr, netRad[i]);
-	  }
+  if (numParams == 5) {
+    panEvap.resize(sz);
+    for (int i = 0; i < sz; i++)
+      BinaryRead(rStr, panEvap[i]);
+  } else {// Giuseppe DEBUG Restart 2012 - END	
+    airTemp.resize(sz); surfTemp.resize(sz); rHumidity.resize(sz);
+    skyCover.resize(sz); windSpeed.resize(sz); atmPress.resize(sz);
+    RadGlobal.resize(sz);
+    for (int i = 0; i < sz; i++) {
+      BinaryRead(rStr, airTemp[i]);
+      BinaryRead(rStr, surfTemp[i]);
+      BinaryRead(rStr, rHumidity[i]);
+      BinaryRead(rStr, skyCover[i]);
+      BinaryRead(rStr, windSpeed[i]);
+      BinaryRead(rStr, atmPress[i]);
+      BinaryRead(rStr, RadGlobal[i]);
+    }
   }
 }
 

--- a/src/tHydro/tHydroMet.cpp
+++ b/src/tHydro/tHydroMet.cpp
@@ -55,13 +55,11 @@ tHydroMet::~tHydroMet()
 		else {
 			if (airTemp){
 				delete [] airTemp;
-				delete [] dewTemp;
 				delete [] surfTemp;
 				delete [] rHumidity;
 				delete [] skyCover;
 				delete [] windSpeed;
 				delete [] atmPress;
-				delete [] vaporPress;
 				delete [] RadGlobal;
 			}
 			if (numParams >= 11) {
@@ -249,18 +247,6 @@ double tHydroMet::getMeanTemp(){
 	return meanTemp;
 }
 
-void tHydroMet::setDewTemp(double *dew){
-	dewTemp = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		dewTemp[ct] = dew[ct];
-	}
-}
-
-double tHydroMet::getDewTemp(int time){
-	return dewTemp[time];
-}
-
-
 void tHydroMet::setSurfTemp(double *surf){
 	surfTemp = new double[numTimes];
 	for(int ct=0;ct<numTimes;ct++){
@@ -305,17 +291,6 @@ double tHydroMet::getRHumidity(int time){
 	return rHumidity[time];
 }
 
-
-void tHydroMet::setVaporPress(double *rh){
-	vaporPress= new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		vaporPress[ct] = rh[ct];
-	}
-}
-
-double tHydroMet::getVaporPress(int time){
-	return vaporPress[time];
-}
 
 void tHydroMet::setWindSpeed(double *wind){
 	windSpeed = new double[numTimes];
@@ -431,18 +406,12 @@ void tHydroMet::writeRestart(fstream & rStr) const
 	else {// Giuseppe DEBUG Restart 2012 - END	
 		for (int i = 0; i < numTimes; i++) {
 			BinaryWrite(rStr, airTemp[i]);
-			BinaryWrite(rStr, dewTemp[i]);
 			BinaryWrite(rStr, surfTemp[i]);
 			BinaryWrite(rStr, rHumidity[i]);
 			BinaryWrite(rStr, skyCover[i]);
 			BinaryWrite(rStr, windSpeed[i]);
 			BinaryWrite(rStr, atmPress[i]);
-			BinaryWrite(rStr, vaporPress[i]);
 			BinaryWrite(rStr, RadGlobal[i]);
-			//BinaryWrite(rStr, RadDirect[i]);
-			//BinaryWrite(rStr, RadDiffuse[i]);
-			//BinaryWrite(rStr, RainMet[i]);
-			//BinaryWrite(rStr, panEvap[i]);
 			if (numParams >= 11)
 				BinaryWrite(rStr, netRad[i]);
 		}
@@ -484,18 +453,12 @@ void tHydroMet::readRestart(fstream & rStr)
   else {// Giuseppe DEBUG Restart 2012 - END	
 	  for (int i = 0; i < numTimes; i++) {
 		  BinaryRead(rStr, airTemp[i]);
-		  BinaryRead(rStr, dewTemp[i]);
 		  BinaryRead(rStr, surfTemp[i]);
 		  BinaryRead(rStr, rHumidity[i]);
 		  BinaryRead(rStr, skyCover[i]);
 		  BinaryRead(rStr, windSpeed[i]);
 		  BinaryRead(rStr, atmPress[i]);
-		  BinaryRead(rStr, vaporPress[i]);
 		  BinaryRead(rStr, RadGlobal[i]);
-		  //BinaryRead(rStr, RadDirect[i]);
-		  //BinaryRead(rStr, RadDiffuse[i]);
-		  //BinaryRead(rStr, RainMet[i]);
-		  //BinaryRead(rStr, panEvap[i]);
 		  if (numParams >= 11)
 			  BinaryRead(rStr, netRad[i]);
 	  }

--- a/src/tHydro/tHydroMet.h
+++ b/src/tHydro/tHydroMet.h
@@ -48,7 +48,6 @@ class tHydroMet
   void setDay(int *);
   void setHour(int *);
   void setAirTemp(double *);
-  void setDewTemp(double *);
   void setSurfTemp(double *);
   void setAtmPress(double *);
   void setSkyCover(double *);
@@ -56,7 +55,6 @@ class tHydroMet
   void setWindSpeed(double *);
   void setNetRad(double *);
   void setPanEvap(double *);
-  void setVaporPress(double *);
   void setRadGlobal(double *);
   void setRadDirect(double *);
   void setRadDiffuse(double *);
@@ -80,7 +78,6 @@ class tHydroMet
   int    getHour(int);
   double getAirTemp(int);
   double getMeanTemp();
-  double getDewTemp(int);
   double getSurfTemp(int);
   double getAtmPress(int);
   double getSkyCover(int);
@@ -88,7 +85,6 @@ class tHydroMet
   double getWindSpeed(int);
   double getNetRad(int);
   double getPanEvap(int);
-  double getVaporPress(int);
   double getRadGlobal(int);
   double getRadDirect(int);
   double getRadDiffuse(int);
@@ -104,8 +100,8 @@ class tHydroMet
   double latitude, longitude;
   double basinLat, basinLong;
   double otherVariable, meanTemp;
-  double *airTemp, *dewTemp, *surfTemp;
-  double *netRad, *panEvap, *vaporPress;
+  double *airTemp, *surfTemp;
+  double *netRad, *panEvap;
   double *rHumidity, *skyCover;
   double *windSpeed, *atmPress;
   double *RadGlobal, *RadDirect, *RadDiffuse, *RainMet;

--- a/src/tHydro/tHydroMet.h
+++ b/src/tHydro/tHydroMet.h
@@ -21,6 +21,7 @@
 #define HYDROMET_H
 
 #include "src/Headers/Inclusions.h"
+#include <vector>
 
 //=========================================================================
 //
@@ -36,77 +37,66 @@ class tHydroMet
   tHydroMet();
   ~tHydroMet();
   void setStation(int);
-  void setLat(double,int);
-  void setLong(double,int);
+  void setLat(double);
+  void setLong(double);
   void setOther(double);
-  void setGmt(int);
-  void setTime(int);
   void setParm(int);
   void setFileName(char*);
-  void setYear(int *);
-  void setMonth(int *);
-  void setDay(int *);
-  void setHour(int *);
-  void setAirTemp(double *);
-  void setSurfTemp(double *);
-  void setAtmPress(double *);
-  void setSkyCover(double *);
-  void setRHumidity(double *);
-  void setWindSpeed(double *);
-  void setNetRad(double *);
-  void setPanEvap(double *);
-  void setRadGlobal(double *);
-  void setRadDirect(double *);
-  void setRadDiffuse(double *);
-  void setRainMet(double *);
+  void setYear(const std::vector<int> &);
+  void setMonth(const std::vector<int> &);
+  void setDay(const std::vector<int> &);
+  void setHour(const std::vector<int> &);
+  void setAirTemp(const std::vector<double> &);
+  void setSurfTemp(const std::vector<double> &);
+  void setAtmPress(const std::vector<double> &);
+  void setSkyCover(const std::vector<double> &);
+  void setRHumidity(const std::vector<double> &);
+  void setWindSpeed(const std::vector<double> &);
+  void setPanEvap(const std::vector<double> &);
+  void setRadGlobal(const std::vector<double> &);
+  void setRadDirect(const std::vector<double> &);
+  void setRadDiffuse(const std::vector<double> &);
+  void setRainMet(const std::vector<double> &);
 
   int    getStation();
-  double getLat(int);
-  double getLong(int);
+  double getLat();
+  double getLong();
   double getOther();
-  int    getGmt();
-  int    getTime();
+  int    getTime() const;
   int    getParm();
   char*  getFileName();
-  int*   getYear();
-  int    getYear(int);
-  int*   getMonth(); 
-  int    getMonth(int);
-  int*   getDay();
-  int    getDay(int);
-  int*   getHour();
-  int    getHour(int);
-  double getAirTemp(int);
+  int    getYear(int) const;
+  int    getMonth(int) const;
+  int    getDay(int) const;
+  int    getHour(int) const;
+  double getAirTemp(int) const;
   double getMeanTemp();
-  double getSurfTemp(int);
-  double getAtmPress(int);
-  double getSkyCover(int);
-  double getRHumidity(int);
-  double getWindSpeed(int);
-  double getNetRad(int);
-  double getPanEvap(int);
-  double getRadGlobal(int);
-  double getRadDirect(int);
-  double getRadDiffuse(int);
-  double getRainMet(int);
+  double getSurfTemp(int) const;
+  double getAtmPress(int) const;
+  double getSkyCover(int) const;
+  double getRHumidity(int) const;
+  double getWindSpeed(int) const;
+  double getPanEvap(int) const;
+  double getRadGlobal(int) const;
+  double getRadDirect(int) const;
+  double getRadDiffuse(int) const;
+  double getRainMet(int) const;
 
   void   writeRestart(fstream &) const;
   void   readRestart(fstream &);
 
  protected:
-  int numTimes, numParams;
-  int gmt, stationID;
+  int numParams;
+  int stationID;
   char fileName[kName];
-  double latitude, longitude;
   double basinLat, basinLong;
   double otherVariable, meanTemp;
-  double *airTemp, *surfTemp;
-  double *netRad, *panEvap;
-  double *rHumidity, *skyCover;
-  double *windSpeed, *atmPress;
-  double *RadGlobal, *RadDirect, *RadDiffuse, *RainMet;
-  int *year, *month, *day, *hour;
-  
+  std::vector<int>    year, month, day, hour;
+  std::vector<double> airTemp, surfTemp;
+  std::vector<double> panEvap;
+  std::vector<double> rHumidity, skyCover;
+  std::vector<double> windSpeed, atmPress;
+  std::vector<double> RadGlobal, RadDirect, RadDiffuse, RainMet;
 };
 
 #endif

--- a/src/tHydro/tIntercept.cpp
+++ b/src/tHydro/tIntercept.cpp
@@ -130,38 +130,56 @@ void tIntercept::DeleteIntercept()
 ** VH NO_DATA NO_DATA
 **
 ***************************************************************************/
-void tIntercept::readLUGrid(char *gridFile) 
+void tIntercept::readLUGrid(char *gridFile)
 {
-	int numParameters;
-	double LUgridlat, LUgridlong;
-	int LUgridgmt;
-	
-	cout<<"\nReading Land-Use Data Grid File in tIntercept: "; 
+	cout<<"\nReading Land-Use Data Grid File in tIntercept: ";
 	cout<< gridFile<<"..."<<endl<<flush;
-	
-	ifstream readFile(gridFile); 
+
+	ifstream readFile(gridFile);
 	if (!readFile) {
 		cout << "\nFile "<<gridFile<<" not found!" << endl;
 		cout << "Exiting Program...\n\n"<<endl;
-		exit(1);}
-	
-	readFile >> numParameters; 
+		exit(1);
+	}
+
+	std::string header;
+	std::getline(readFile, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != 3) {
+		cout << "\nError: LU grid file '" << gridFile << "' has " << colCount
+		     << " columns, expected 3 (Variable,BasePath,FileExtension)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(1);
+	}
+
+	std::vector<std::vector<std::string>> rows;
+	std::string line;
+	while (std::getline(readFile, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::vector<std::string> row(3);
+		for (int j = 0; j < 3; j++)
+			std::getline(ss, row[j], ',');
+		rows.push_back(row);
+	}
+	readFile.close();
+
+	int numParameters = static_cast<int>(rows.size());
 	nParmLU = numParameters;
-	readFile >> LUgridlat;
-	readFile >> LUgridlong;
-	readFile >> LUgridgmt;
 
 	LUgridBaseNames = new char*[numParameters];
 	LUgridExtNames = new char*[numParameters];
 	LUgridParamNames = new char*[numParameters];
-	
+
 	for (int ct=0;ct<numParameters;ct++) {
 		LUgridParamNames[ct] = new char[10];
 		LUgridBaseNames[ct] = new char[kName];
 		LUgridExtNames[ct] = new char[10];
-		readFile >> LUgridParamNames[ct];
-		readFile >> LUgridBaseNames[ct];
-		readFile >> LUgridExtNames[ct];
+		strncpy(LUgridParamNames[ct], rows[ct][0].c_str(), 9);  LUgridParamNames[ct][9] = '\0';
+		strncpy(LUgridBaseNames[ct],  rows[ct][1].c_str(), kName - 1); LUgridBaseNames[ct][kName - 1] = '\0';
+		strncpy(LUgridExtNames[ct],   rows[ct][2].c_str(), 9);  LUgridExtNames[ct][9] = '\0';
 	}
 	return;
 }

--- a/src/tInOut/tInputFile.cpp
+++ b/src/tInOut/tInputFile.cpp
@@ -211,6 +211,8 @@ void tInputFile::ReadItem( char * theString, const char *itemCode )
 	
 	if( !( infile.eof() ) ){
 		infile.getline( theString, kMaxNameLength );
+		int len = strlen(theString);
+		if (len > 0 && theString[len-1] == '\r') theString[len-1] = '\0';
 	}
 	else {
 		cout<<"\nError: Expected to read the parameter '" << itemCode

--- a/src/tRasTin/tInvariant.cpp
+++ b/src/tRasTin/tInvariant.cpp
@@ -65,6 +65,7 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
 
 	std::string header;
 	std::getline(Inp0, header);
+	if (!header.empty() && header.back() == '\r') header.pop_back();
 	int colCount = 1;
 	for (char c : header)
 		if (c == ',') ++colCount;
@@ -78,6 +79,8 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
 	std::vector<std::vector<double>> rows;
 	std::string line;
 	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::string token;
@@ -156,6 +159,7 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
 
         std::string header;
         std::getline(readFile, header);
+        if (!header.empty() && header.back() == '\r') header.pop_back();
         int colCount = 1;
         for (char c : header)
             if (c == ',') ++colCount;
@@ -169,6 +173,8 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
         std::vector<std::vector<std::string>> rows;
         std::string line;
         while (std::getline(readFile, line)) {
+            if (line.empty()) continue;
+            if (line.back() == '\r') line.pop_back();
             if (line.empty()) continue;
             std::istringstream ss(line);
             std::vector<std::string> row(3);
@@ -435,6 +441,7 @@ void GenericSoilData::SetSoilParameters(tMesh<tCNode> *mesh,
 
 	std::string header;
 	std::getline(Inp0, header);
+	if (!header.empty() && header.back() == '\r') header.pop_back();
 	int colCount = 1;
 	for (char c : header)
 		if (c == ',') ++colCount;
@@ -448,6 +455,8 @@ void GenericSoilData::SetSoilParameters(tMesh<tCNode> *mesh,
 	std::vector<std::vector<double>> rows;
 	std::string line;
 	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::string token;
@@ -626,6 +635,7 @@ GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 
 	std::string header;
 	std::getline(Inp0, header);
+	if (!header.empty() && header.back() == '\r') header.pop_back();
 	int colCount = 1;
 	for (char c : header)
 		if (c == ',') ++colCount;
@@ -639,6 +649,8 @@ GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 	std::vector<std::vector<double>> rows;
 	std::string line;
 	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::string token;
@@ -723,6 +735,7 @@ void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 
 	std::string header;
 	std::getline(Inp0, header);
+	if (!header.empty() && header.back() == '\r') header.pop_back();
 	int colCount = 1;
 	for (char c : header)
 		if (c == ',') ++colCount;
@@ -736,6 +749,8 @@ void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 	std::vector<std::vector<double>> rows;
 	std::string line;
 	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::string token;

--- a/src/tRasTin/tInvariant.cpp
+++ b/src/tRasTin/tInvariant.cpp
@@ -35,7 +35,7 @@
 GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh, 
 								 tInputFile *input, tResample *resamp)
 {  
-	int np, id;
+	int id;
 	double *sc;
     
     // Changes added by Giuseppe in August 2016 to allow reading soil grids
@@ -55,34 +55,69 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
 		id++;
 	}
 	
+	const int kSoilColumns = 12; // ID + 11 soil properties
 	ifstream Inp0(soilTable);
 	if (!Inp0) {
 		cout <<"\nFile "<<soilTable<<" not found!"<<endl;
 		cout <<"Exiting Program...\n\n"<<endl;
 		exit(2);
 	}
-	
-	// Reads # of soil classes and # parameters
-	Inp0 >> numClass >> np; 
-	
-	assert(numClass > 0 && np > 0);
+
+	std::string header;
+	std::getline(Inp0, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != kSoilColumns) {
+		cout << "\nError: Soil table '" << soilTable << "' has " << colCount
+		     << " columns, expected " << kSoilColumns << " (ID + 11 parameters)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
+	std::vector<std::vector<double>> rows;
+	std::string line;
+	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::string token;
+		std::vector<double> row(kSoilColumns);
+		for (int j = 0; j < kSoilColumns; j++) {
+			std::getline(ss, token, ',');
+			row[j] = std::stod(token);
+		}
+		rows.push_back(row);
+	}
+	Inp0.close();
+
+	numClass = static_cast<int>(rows.size());
+	assert(numClass > 0);
+
+	int maxSoilID = 0;
+	for (cn=niter.FirstP(); niter.IsActive(); cn=niter.NextP())
+		maxSoilID = std::max(maxSoilID, cn->getSoilID());
+	if (maxSoilID > numClass) {
+		cout << "\nError: Soil raster contains class ID " << maxSoilID
+		     << " but soil table '" << soilTable << "' only has "
+		     << numClass << " rows." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
 	SoilClass = new SoilType* [numClass];
 	assert(SoilClass != nullptr);
-	
-	sc = new double [np];
+
+	sc = new double [kSoilColumns];
 	assert(sc != nullptr);
-	
-	// Reads in the soil parameters 
-	for (int i=0; i < numClass; i++) {
-		for (int j=0; j < np; j++)
-			Inp0 >> sc[j];
-		SoilClass[i] = new SoilType(sc, np);
+
+	for (int i = 0; i < numClass; i++) {
+		for (int j = 0; j < kSoilColumns; j++)
+			sc[j] = rows[i][j];
+		SoilClass[i] = new SoilType(sc, kSoilColumns);
 		assert(SoilClass[i] != nullptr);
 	}
-	
-	Inp0.close();
 	delete [] sc;
-    
+
     // Giuseppe 2016 - Assign the soil properties to the nodes via the set functions
     id = 0;
     for (cn=niter.FirstP(); niter.IsActive(); cn=niter.NextP()) {
@@ -107,50 +142,56 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
     //else if (stdgrid_opt == 1)        // Comment out later Giuseppe 2016
     if (stdgrid_opt == 1)
     {
-        
-        int sID_array = 0;
-        for (cn=niter.FirstP(); niter.IsActive(); cn=niter.NextP()) {
-            sID_array++;
-        }
-        int Asize = sID_array;
-        
-        // Read the path to the soil grids from the gdf file
         input->ReadItem(scfile, "SCGRID");
-        
-        int sID = 0;
-        int numParameters;
-        double SCgridlat;
-        double SCgridlong;
-        double SCgridgmt;
-        
+
         cout<<"\nReading Soil Cover Data Grid File: ";
         cout<< scfile<<"..."<<endl<<flush;
-        
+
         ifstream readFile(scfile);
         if (!readFile) {
             cout << "\nFile "<<scfile<<" not found!" << endl;
             cout << "Exiting Program...\n\n"<<endl;
-            exit(1);}
-        
-        readFile >> numParameters; //Reads first line of the *.gdf file (11 parameters)
-        
-        //Read default parameters from the second line of the *.gdf file
-        readFile >> SCgridlat;
-        readFile >> SCgridlong;
-        readFile >> SCgridgmt;
-        
-        // Initialize variable with the names of the soil parameters and corresponding files
+            exit(1);
+        }
+
+        std::string header;
+        std::getline(readFile, header);
+        int colCount = 1;
+        for (char c : header)
+            if (c == ',') ++colCount;
+        if (colCount != 3) {
+            cout << "\nError: Soil grid file '" << scfile << "' has " << colCount
+                 << " columns, expected 3 (Variable,BasePath,FileExtension)." << endl;
+            cout << "Exiting Program...\n\n" << endl;
+            exit(1);
+        }
+
+        std::vector<std::vector<std::string>> rows;
+        std::string line;
+        while (std::getline(readFile, line)) {
+            if (line.empty()) continue;
+            std::istringstream ss(line);
+            std::vector<std::string> row(3);
+            for (int j = 0; j < 3; j++)
+                std::getline(ss, row[j], ',');
+            rows.push_back(row);
+        }
+        readFile.close();
+
+        int numParameters = static_cast<int>(rows.size());
         SCgridBaseNames.resize(numParameters);
         SCgridParamNames.resize(numParameters);
         SCgridExtNames.resize(numParameters);
         SCgridName.resize(numParameters);
-        
+
         for (int ct=0;ct<numParameters;ct++) {
 
-            string temp;
-            readFile >> temp;
-            SCgridParamNames[ct] = make_unique<char[]>(temp.length() + 1);
-            strcpy(SCgridParamNames[ct].get(), temp.c_str());
+            const std::string &paramName = rows[ct][0];
+            const std::string &baseName  = rows[ct][1];
+            const std::string &extName   = rows[ct][2];
+
+            SCgridParamNames[ct] = make_unique<char[]>(paramName.length() + 1);
+            strcpy(SCgridParamNames[ct].get(), paramName.c_str());
 
             if ( (strcmp(SCgridParamNames[ct].get(),"KS")!=0) &&
                 (strcmp(SCgridParamNames[ct].get(),"TS")!=0) &&
@@ -168,12 +209,10 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
                 cout << "\tCheck and re-run the program" << endl;
                 cout << "\nExiting Program..."<<endl<<endl;
                 exit(1);
-                
             }
 
-            readFile >> temp;
-            SCgridBaseNames[ct] = make_unique<char[]>(temp.length() + 1);
-            strcpy(SCgridBaseNames[ct].get(), temp.c_str());
+            SCgridBaseNames[ct] = make_unique<char[]>(baseName.length() + 1);
+            strcpy(SCgridBaseNames[ct].get(), baseName.c_str());
 
             if (strcmp(SCgridBaseNames[ct].get(),"NO_DATA")==0) {
                 Cout << "\nCannot use NO_DATA for SC Grids"<<endl;
@@ -181,15 +220,13 @@ GenericSoilData::GenericSoilData(tMesh<tCNode> *mesh,
                 exit(1);
             }
 
-            readFile >> temp;
-            SCgridExtNames[ct] = make_unique<char[]>(temp.length() + 1);
-            strcpy(SCgridExtNames[ct].get(), temp.c_str());
+            SCgridExtNames[ct] = make_unique<char[]>(extName.length() + 1);
+            strcpy(SCgridExtNames[ct].get(), extName.c_str());
 
-            SCgridName[ct] = make_unique<char[]>(100);//new char[100];
-
-            strcpy(SCgridName[ct].get(),SCgridBaseNames[ct].get()); // copy the first string into SCgridName[ct]
-            strcat(SCgridName[ct].get(),"."); // append "."
-            strcat(SCgridName[ct].get(),SCgridExtNames[ct].get()); // append SCgridExtNames[ct]
+            SCgridName[ct] = make_unique<char[]>(100);
+            strcpy(SCgridName[ct].get(), baseName.c_str());
+            strcat(SCgridName[ct].get(), ".");
+            strcat(SCgridName[ct].get(), extName.c_str());
             
             if (strcmp(SCgridParamNames[ct].get(),"KS")==0)
             {
@@ -371,9 +408,7 @@ GenericSoilData::~GenericSoilData() {
 void GenericSoilData::SetSoilParameters(tMesh<tCNode> *mesh,
 										tResample *resamp, tInputFile &infile, int option)
 {
-	int np, nt;
 	int id;
-	double troyan;
 	
 	if ( option ) {     // Needs a new soil resampling 
 		Cout<<"\nResampling Soils......"<<endl<<flush;
@@ -390,53 +425,75 @@ void GenericSoilData::SetSoilParameters(tMesh<tCNode> *mesh,
 	}
 	
 	infile.ReadItem(soilTable, "SOILTABLENAME"); // input table
+	const int kSoilColumns = 12; // ID + 11 soil properties
 	ifstream Inp0(soilTable);
 	if (!Inp0) {
 		cout <<"File "<<soilTable<<" not found!"<<endl;
 		cout <<"Exiting Program...\n\n"<<endl;
 		exit(2);
 	}
-	
-	Inp0>>nt>>np;           // Reads # of soil classes and # parameters
-	
-	if ( option ) {         // Needs a new soil resampling 
+
+	std::string header;
+	std::getline(Inp0, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != kSoilColumns) {
+		cout << "\nError: Soil table '" << soilTable << "' has " << colCount
+		     << " columns, expected " << kSoilColumns << " (ID + 11 parameters)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
+	std::vector<std::vector<double>> rows;
+	std::string line;
+	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::string token;
+		std::vector<double> row(kSoilColumns);
+		for (int j = 0; j < kSoilColumns; j++) {
+			std::getline(ss, token, ',');
+			row[j] = std::stod(token);
+		}
+		rows.push_back(row);
+	}
+	Inp0.close();
+
+	int rowCount = static_cast<int>(rows.size());
+
+	if ( option ) {         // Needs a new soil resampling
 		for (int iprop=0;iprop < numClass;iprop++)
 			delete SoilClass[iprop];
 		delete [] SoilClass;
-		
-		numClass = nt;
-		assert(numClass > 0 && np > 0);
-		
-		// Create 'numClass' of 'SoilType' pointers
+
+		numClass = rowCount;
+		assert(numClass > 0);
+
 		SoilClass = new SoilType* [numClass];
 		assert(SoilClass != 0);
-		
-		double *sc;
-		sc = new double [np];
+
+		double *sc = new double [kSoilColumns];
 		assert(sc != 0);
-		
-		// Create each 'SoilType' object
-		for (int i=0; i < numClass; i++)    {
-			for (int j=0; j < np; j++)
-				Inp0 >> sc[j];
-			SoilClass[i] = new SoilType(sc, np);
+
+		for (int i=0; i < numClass; i++) {
+			for (int j=0; j < kSoilColumns; j++)
+				sc[j] = rows[i][j];
+			SoilClass[i] = new SoilType(sc, kSoilColumns);
 			assert(SoilClass[i] != 0);
 		}
-		Inp0.close();
 		delete [] sc;
 	}
 	else if ( !option ) {
-		if (nt != numClass) {
+		if (rowCount != numClass) {
 			cout<<"\nWarning! Number of classes does not correspond to previous";
-			cout <<"\nProceeding with latter number of classes"<<endl<<flush; 
+			cout <<"\nProceeding with latter number of classes"<<endl<<flush;
 		}
-		for (int i=0; i < numClass; i++) {
-			for (int j=0; j < np; j++) {
-				Inp0 >> troyan;
-				SoilClass[i]->setProperty( j, troyan );
-			}
+		int readCount = std::min(numClass, rowCount);
+		for (int i=0; i < readCount; i++) {
+			for (int j=0; j < kSoilColumns; j++)
+				SoilClass[i]->setProperty( j, rows[i][j] );
 		}
-		Inp0.close();
 	}
 	}
 
@@ -541,10 +598,10 @@ void SoilType::setProperty(int id, double param) {
 **  Constructor and Destructor for GenericLandData Class
 **
 ***************************************************************************/
-GenericLandData::GenericLandData(tMesh<tCNode> *mesh, 
+GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 								 tInputFile *input, tResample *resamp)
-{  
-	int np, id;
+{
+	int id;
 	double *lc;
 	
 	input->ReadItem(landTable, "LANDTABLENAME");   // input table
@@ -559,32 +616,67 @@ GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 		id++;
 	}
 	
+	const int kLandColumns = 13; // ID + 12 land use properties
 	ifstream Inp0(landTable);
 	if (!Inp0) {
 		cout <<"\nFile "<<landTable<<" not found!"<<endl;
 		cout <<"Exiting Program...\n\n"<<endl;
 		exit(2);
 	}
-	
-	// Reads # of land classes and # parameters
-	Inp0 >> numClass >> np; 
-	
-	assert(numClass > 0 && np > 0);
+
+	std::string header;
+	std::getline(Inp0, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != kLandColumns) {
+		cout << "\nError: Land use table '" << landTable << "' has " << colCount
+		     << " columns, expected " << kLandColumns << " (ID + 12 parameters)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
+	std::vector<std::vector<double>> rows;
+	std::string line;
+	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::string token;
+		std::vector<double> row(kLandColumns);
+		for (int j = 0; j < kLandColumns; j++) {
+			std::getline(ss, token, ',');
+			row[j] = std::stod(token);
+		}
+		rows.push_back(row);
+	}
+	Inp0.close();
+
+	numClass = static_cast<int>(rows.size());
+	assert(numClass > 0);
+
+	int maxLandID = 0;
+	for (cn=niter.FirstP(); niter.IsActive(); cn=niter.NextP())
+		maxLandID = std::max(maxLandID, cn->getLandUse());
+	if (maxLandID > numClass) {
+		cout << "\nError: Land use raster contains class ID " << maxLandID
+		     << " but land use table '" << landTable << "' only has "
+		     << numClass << " rows." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
 	LandClass = new LandType* [numClass];
 	assert(LandClass != 0);
-	
-	lc = new double [np];
+
+	lc = new double [kLandColumns];
 	assert(lc != 0);
-	
-	// Reads in the land parameters 
-	for (int i=0; i < numClass; i++) {
-		for (int j=0; j < np; j++) {
-			Inp0 >> lc[j];}
-		LandClass[i] = new LandType(lc, np);
+
+	for (int i = 0; i < numClass; i++) {
+		for (int j = 0; j < kLandColumns; j++)
+			lc[j] = rows[i][j];
+		LandClass[i] = new LandType(lc, kLandColumns);
 		assert(LandClass[i] != 0);
 	}
-	
-	Inp0.close();
 	delete [] lc;
 }
 
@@ -604,9 +696,7 @@ GenericLandData::~GenericLandData() {
 void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 										 tResample *resamp, tInputFile &infile, int option)
 {
-	int np, nt;
 	int id;
-	double troyan;
 	
 	if ( option ) {              // Needs a new soil resampling 
 		Cout<<"\nResampling Landuse......"<<endl<<flush;
@@ -623,51 +713,74 @@ void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 	}
 	
 	infile.ReadItem(landTable, "LANDTABLENAME"); // Input table
+	const int kLandColumns = 13; // ID + 12 land use properties
 	ifstream Inp0(landTable);
 	if (!Inp0) {
 		cout <<"File "<<landTable<<" not found!!!"<<endl;
 		cout<<", tInvariant Error"<<endl;
 		exit(2);
 	}
-	
-	Inp0>>nt>>np; // Reads # of landuse classes and # parameters
-	
-	if ( option ) { // Needs a new landuse resampling 
+
+	std::string header;
+	std::getline(Inp0, header);
+	int colCount = 1;
+	for (char c : header)
+		if (c == ',') ++colCount;
+	if (colCount != kLandColumns) {
+		cout << "\nError: Land use table '" << landTable << "' has " << colCount
+		     << " columns, expected " << kLandColumns << " (ID + 12 parameters)." << endl;
+		cout << "Exiting Program...\n\n" << endl;
+		exit(2);
+	}
+
+	std::vector<std::vector<double>> rows;
+	std::string line;
+	while (std::getline(Inp0, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::string token;
+		std::vector<double> row(kLandColumns);
+		for (int j = 0; j < kLandColumns; j++) {
+			std::getline(ss, token, ',');
+			row[j] = std::stod(token);
+		}
+		rows.push_back(row);
+	}
+	Inp0.close();
+
+	int rowCount = static_cast<int>(rows.size());
+
+	if ( option ) { // Needs a new landuse resampling
 		for (int iprop=0;iprop < numClass;iprop++)
 			delete LandClass[iprop];
 		delete [] LandClass;
-		
-		numClass = nt;
-		assert(numClass > 0 && np > 0);
+
+		numClass = rowCount;
+		assert(numClass > 0);
 		LandClass = new LandType* [numClass];
 		assert(LandClass != 0);
-		
-		double *lc;
-		lc = new double [np];
+
+		double *lc = new double [kLandColumns];
 		assert(lc != 0);
-		
+
 		for (int i=0; i < numClass; i++) {
-			for (int j=0; j < np; j++)
-				Inp0 >> lc[j];
-			LandClass[i] = new LandType(lc, np);
+			for (int j=0; j < kLandColumns; j++)
+				lc[j] = rows[i][j];
+			LandClass[i] = new LandType(lc, kLandColumns);
 			assert(LandClass[i] != 0);
 		}
-		Inp0.close();
 		delete [] lc;
 	}
 	else if ( !option ) {
-		if (nt != numClass) {
+		if (rowCount != numClass) {
 			cout<<"\nWarning! Number of classes does not correspond to previous";
-			cout <<"\nProceeding with latter number of classes"<<endl<<flush; 
+			cout <<"\nProceeding with latter number of classes"<<endl<<flush;
 		}
-		
-		for (int i=0; i < numClass; i++) {
-			for (int j=0; j < np; j++) {
-				Inp0 >> troyan;
-				LandClass[i]->setProperty( j, troyan );
-			}
+		int readCount = std::min(numClass, rowCount);
+		for (int i=0; i < readCount; i++) {
+			for (int j=0; j < kLandColumns; j++)
+				LandClass[i]->setProperty( j, rows[i][j] );
 		}
-		Inp0.close();
 	}
 	return;
 }

--- a/src/tRasTin/tRainGauge.cpp
+++ b/src/tRasTin/tRainGauge.cpp
@@ -25,8 +25,8 @@
 
 tRainGauge::tRainGauge()
 {
-	numTimes = 0;
 	stationID = 0;
+	fileName = nullptr;
 	basinLong = 0.0;
 	basinLat = 0.0;
 	elev = 0.0;
@@ -34,14 +34,7 @@ tRainGauge::tRainGauge()
 
 tRainGauge::~tRainGauge()
 {
-	if (numTimes) {
-		delete [] fileName;
-		delete [] rain;
-		delete [] year;
-		delete [] month;
-		delete [] day;
-		delete [] hour;
-	}
+	delete[] fileName;
 }
 
 //=========================================================================
@@ -54,7 +47,7 @@ tRainGauge::~tRainGauge()
 
 /***************************************************************************
 **
-** Set() and Get() Functions for Station Indentifiers
+** Set() and Get() Functions for Station Identifiers
 **
 ***************************************************************************/
 
@@ -70,7 +63,7 @@ void tRainGauge::setLat(double lat){
 	basinLat = lat;
 }
 
-double tRainGauge::getLat(){ 
+double tRainGauge::getLat(){
 	return basinLat;
 }
 
@@ -82,42 +75,22 @@ double tRainGauge::getLong(){
 	return basinLong;
 }
 
-// SKY2008Snow from AJR2007 starts here
 void tRainGauge::setElev(double value){
-  elev = value;//AJR @ NMT 2007
+	elev = value;
 }
 
 double tRainGauge::getElev(){
-  return elev;//AJR @ NMT 2007
+	return elev;
 }
-// SKY2008Snow from AJR2007 ends here
-
-void tRainGauge::setTime(int time){
-	numTimes = time;
-}
-
-int tRainGauge::getTime(){
-	return numTimes;
-}
-
 
 void tRainGauge::setFileName(char* file){
 	fileName = new char[kName];
-	for(int ct = 0;ct<kName;ct++){
+	for (int ct = 0; ct < kName; ct++)
 		fileName[ct] = file[ct];
-	}
 }
 
 char* tRainGauge::getFileName(){
 	return fileName;
-}
-
-void tRainGauge::setParm(int par){
-	numParams = par;
-}
-
-int tRainGauge::getParm(){
-	return numParams;
 }
 
 /***************************************************************************
@@ -126,56 +99,40 @@ int tRainGauge::getParm(){
 **
 ***************************************************************************/
 
-void tRainGauge::setYear(int *syear){ 
-	year = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		year[ct] = syear[ct]; 
-	}
+void tRainGauge::setYear(const std::vector<int>& v){
+	year = v;
 }
 
 int tRainGauge::getYear(int time){
 	return year[time];
 }
 
-void tRainGauge::setMonth(int *smonth){
-	month = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		month[ct] = smonth[ct];
-	}
+void tRainGauge::setMonth(const std::vector<int>& v){
+	month = v;
 }
 
 int tRainGauge::getMonth(int time){
 	return month[time];
 }
 
-void tRainGauge::setDay(int *sday){
-	day = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		day[ct] = sday[ct];
-	}
+void tRainGauge::setDay(const std::vector<int>& v){
+	day = v;
 }
 
 int tRainGauge::getDay(int time){
 	return day[time];
 }
 
-void tRainGauge::setHour(int *shour){
-	hour = new int[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		hour[ct] = shour[ct];
-	}
+void tRainGauge::setHour(const std::vector<int>& v){
+	hour = v;
 }
-
 
 int tRainGauge::getHour(int time){
 	return hour[time];
 }
 
-void tRainGauge::setRain(double *r){
-	rain = new double[numTimes];
-	for(int ct=0;ct<numTimes;ct++){
-		rain[ct] = r[ct];
-	}
+void tRainGauge::setRain(const std::vector<double>& v){
+	rain = v;
 }
 
 double tRainGauge::getRain(int time){
@@ -192,22 +149,20 @@ double tRainGauge::getRain(int time){
 
 void tRainGauge::writeRestart(fstream & rStr) const
 {
-  BinaryWrite(rStr, numTimes);
-  BinaryWrite(rStr, stationID);
-  BinaryWrite(rStr, numParams);
-  for (int i = 0; i < numTimes; i++) {
-    BinaryWrite(rStr, year[i]);
-    BinaryWrite(rStr, month[i]);
-    BinaryWrite(rStr, day[i]);
-    BinaryWrite(rStr, hour[i]);
-  }
-
-  BinaryWrite(rStr, basinLat);
-  BinaryWrite(rStr, basinLong);
-  for (int i = 0; i < numTimes; i++)
-    BinaryWrite(rStr, rain[i]);
-
-  BinaryWrite(rStr, elev);      // snow
+	int sz = static_cast<int>(year.size());
+	BinaryWrite(rStr, sz);
+	BinaryWrite(rStr, stationID);
+	for (int i = 0; i < sz; i++) {
+		BinaryWrite(rStr, year[i]);
+		BinaryWrite(rStr, month[i]);
+		BinaryWrite(rStr, day[i]);
+		BinaryWrite(rStr, hour[i]);
+	}
+	BinaryWrite(rStr, basinLat);
+	BinaryWrite(rStr, basinLong);
+	for (int i = 0; i < sz; i++)
+		BinaryWrite(rStr, rain[i]);
+	BinaryWrite(rStr, elev);
 }
 
 
@@ -219,22 +174,25 @@ void tRainGauge::writeRestart(fstream & rStr) const
 
 void tRainGauge::readRestart(fstream & rStr)
 {
-  BinaryRead(rStr, numTimes);
-  BinaryRead(rStr, stationID);
-  BinaryRead(rStr, numParams);
-  for (int i = 0; i < numTimes; i++) {
-    BinaryRead(rStr, year[i]);
-    BinaryRead(rStr, month[i]);
-    BinaryRead(rStr, day[i]);
-    BinaryRead(rStr, hour[i]);
-  }
-
-  BinaryRead(rStr, basinLat);
-  BinaryRead(rStr, basinLong);
-  for (int i = 0; i < numTimes; i++)
-    BinaryRead(rStr, rain[i]);
-
-  BinaryRead(rStr, elev);      // snow
+	int sz;
+	BinaryRead(rStr, sz);
+	BinaryRead(rStr, stationID);
+	year.resize(sz);
+	month.resize(sz);
+	day.resize(sz);
+	hour.resize(sz);
+	for (int i = 0; i < sz; i++) {
+		BinaryRead(rStr, year[i]);
+		BinaryRead(rStr, month[i]);
+		BinaryRead(rStr, day[i]);
+		BinaryRead(rStr, hour[i]);
+	}
+	BinaryRead(rStr, basinLat);
+	BinaryRead(rStr, basinLong);
+	rain.resize(sz);
+	for (int i = 0; i < sz; i++)
+		BinaryRead(rStr, rain[i]);
+	BinaryRead(rStr, elev);
 }
 
 //=========================================================================

--- a/src/tRasTin/tRainGauge.h
+++ b/src/tRasTin/tRainGauge.h
@@ -9,7 +9,7 @@
 
 /***************************************************************************
 **
-**  tRainGauge.h:   Header file for class tRainGauge. Modeled after 
+**  tRainGauge.h:   Header file for class tRainGauge. Modeled after
 **                  tHydroMet
 **
 **  This class encapsulates the rainfall data from a raingauge station.
@@ -36,51 +36,43 @@ class tRainGauge
  public:
   tRainGauge();
   ~tRainGauge();
+
   void setStation(int);
   void setLat(double);
   void setLong(double);
-
   // SKY2008Snow from AJR2007
   void setElev(double); //AJR @ NMT 2007
-
-  void setTime(int);
   void setFileName(char*);
-  void setYear(int *);
-  void setMonth(int *);
-  void setDay(int *);
-  void setHour(int *);
-  void setRain(double *);
-  void setParm(int);
-  
+  void setYear(const std::vector<int>&);
+  void setMonth(const std::vector<int>&);
+  void setDay(const std::vector<int>&);
+  void setHour(const std::vector<int>&);
+  void setRain(const std::vector<double>&);
+
   int getStation();
   double getLat();
   double getLong();
 
   // SKY2008Snow from AJR2007
   double getElev(); //AJR @ NMT 2007
-
-  int getTime();
   char* getFileName();
   int getYear(int);
   int getMonth(int);
   int getDay(int);
   int getHour(int);
-  int getParm();
   double getRain(int);
   void writeRestart(fstream &) const;
   void readRestart(fstream &);
-  
+
  protected:
-  int numTimes, stationID, numParams;
+  int stationID;
   char *fileName;
   double basinLat, basinLong;
 
   // SKY2008Snow from AJR2007
   double elev;//AJR @ NMT 2007
-
-  double *rain;
-  int *year, *month, *day, *hour;
-  
+  std::vector<int>    year, month, day, hour;
+  std::vector<double> rain;
 };
 
 #endif

--- a/src/tRasTin/tRainfall.cpp
+++ b/src/tRasTin/tRainfall.cpp
@@ -426,92 +426,81 @@ void tRainfall::NewRainData(int time, tRunTimer *timer)
 ** the raingauges used for rainfall input. Creates an array of tRainGauge
 ** for storing data. (see tRainGauge.h)
 **
-** Format for RainGaugeStation File:
+** Format for RainGaugeStation File (CSV):
 **
-** Header:
-** nStations nParams (6)
+** Header (required, 5 columns):
+** ID,DataFile,Northing,Easting,Elevation
 **
-** Body:
-** StationID# FilePath Latitude Longitude RecordLength NumParm
-**
-** The file should have N rows corresponding to the N number of stations.
-** and M columns corresponding to the data for each station.
-**
-** StationID  (int)         1->N
-** FilePath   (string)      File name and path for the station datafile
-** Reference Latitude  (double)  Station latitude  (basin projection)
-** Reference Longitude (double)  Station longitude (basin projection)
-** RecordLength  (int)      Number records for each station
-** NumParm (int)            Number of parameter in each station record
+** Body (one row per station):
+** ID        (int)     Station identifier
+** DataFile  (string)  Path to the station MDF data file
+** Northing  (double)  Station northing coordinate (basin projection)
+** Easting   (double)  Station easting coordinate (basin projection)
+** Elevation (double)  Station elevation in meters
 **
 ***************************************************************************/
-void tRainfall::readGaugeStat(char *stationfile) 
+void tRainfall::readGaugeStat(char *stationfile)
 {
-	int nStations, nParams;
-	int stationID, numTimes, numParams;
-	double rlat, rlong;
+	Cout<<"\nReading Rain Gauge Station File '"
+	    << stationfile <<"'..."<<endl<<flush;
 
-	// SKY2008Snow from AJR2007
-	double elevation; // AJR @ NMT 2007
-
-	char fileName[kName];
-
-	// SKY2008Snow from AJR2007
-	//assert(fileName != 0); //WR--09192023: comparison of array 'fileName' not equal to a null pointer is always true
-	
-	Cout<<"\nReading Rain Gauge Station File '";
-	Cout<< stationfile<<"'..."<<endl<<flush;
-	
-	ifstream readFile(stationfile); 
+	ifstream readFile(stationfile);
 	if (!readFile) {
 		cout << "File "<<stationfile<<" not found." << endl;
 		cout<<"Exiting Program...\n\n"<<endl;
 		exit(1);
 	}
-	
-	readFile >> nStations;
-	readFile >> nParams;
 
-	rainGauges = new tRainGauge[nStations];
-	assert(rainGauges != 0);
-	numStations = nStations;
-	
-	for (int count=0;count<nStations;count++) {
-		for (int ct=0;ct<nParams;ct++) {
-			if (ct==0) {
-				readFile >> stationID;
-				rainGauges[count].setStation(stationID);
-			}
-			if (ct==1) {
-				readFile >> fileName;
-				rainGauges[count].setFileName(fileName);
-			}
-			if (ct==2) {
-				readFile >> rlat;
-				rainGauges[count].setLat(rlat);
-			}
-			if (ct==3) {
-				readFile >> rlong;
-				rainGauges[count].setLong(rlong);
-			}
-			if (ct==4) {
-				readFile >> numTimes;
-				rainGauges[count].setTime(numTimes);
-			}
-			if (ct==5) {
-				readFile >> numParams;
-				rainGauges[count].setParm(numParams);
-			}
-
-			// SKY2008Snow from AJR2007
-			if(ct==6){
-				readFile >> elevation;
-				rainGauges[count].setElev(elevation);
-			}
-
+	// Validate CSV header: ID,DataFile,Northing,Easting,Elevation
+	std::string headerLine;
+	std::getline(readFile, headerLine);
+	{
+		std::istringstream hss(headerLine);
+		std::string token;
+		int ncols = 0;
+		while (std::getline(hss, token, ',')) ncols++;
+		if (ncols != 5) {
+			cerr << "\nError: Rain gauge station file '" << stationfile
+			     << "' header must have 5 columns "
+			        "(ID,DataFile,Northing,Easting,Elevation)." << endl;
+			exit(1);
 		}
 	}
+
+	// Read all data rows
+	std::vector<std::string> rows;
+	std::string line;
+	while (std::getline(readFile, line)) {
+		if (!line.empty()) rows.push_back(line);
+	}
 	readFile.close();
+
+	numStations = static_cast<int>(rows.size());
+	rainGauges  = new tRainGauge[numStations];
+	assert(rainGauges != 0);
+
+	for (int count = 0; count < numStations; count++) {
+		std::istringstream ss(rows[count]);
+		std::string token;
+		char fileName[kName];
+
+		std::getline(ss, token, ',');
+		rainGauges[count].setStation(std::stoi(token));
+
+		std::getline(ss, token, ',');
+		strncpy(fileName, token.c_str(), kName - 1);
+		fileName[kName - 1] = '\0';
+		rainGauges[count].setFileName(fileName);
+
+		std::getline(ss, token, ',');
+		rainGauges[count].setLat(std::stod(token));
+
+		std::getline(ss, token, ',');
+		rainGauges[count].setLong(std::stod(token));
+
+		std::getline(ss, token, ',');
+		rainGauges[count].setElev(std::stod(token));
+	}
 }
 
 /***************************************************************************
@@ -519,91 +508,80 @@ void tRainfall::readGaugeStat(char *stationfile)
 ** tRainfall::readGaugeData() Function
 **
 **
-** Reads and assigns data values to tRainGauge objects. 
-** File Format:
-** 
-** Description Line: 
-**      Abbreviations of Parameters as character strings
-**      Ex. Y M D H R     
+** Reads and assigns data values to tRainGauge objects.
+** File Format (CSV):
 **
-** Body Lines:
-**      Values for each parameters. Read in as ints and doubles
-**      Ex. Year (4 digit number), Month, Day, Hour (int)
-**          Rain (double) in mm/hr
+** Header (required, 5 columns):
+** Year,Month,Day,Hour,Rain_mm/hr
 **
-**      No Data Flag as 9999.99 for doubles
+** Body Lines (one row per timestep):
+**      Year  (int)    4-digit year
+**      Month (int)    Month (1-12)
+**      Day   (int)    Day of month
+**      Hour  (int)    Hour of day
+**      Rain  (double) Rainfall rate in mm/hr; values <0 or >200 flagged as NO_DATA (9999.99)
 **
 ***************************************************************************/
-void tRainfall::readGaugeData(int num) 
+void tRainfall::readGaugeData(int num)
 {
-	int numParams, numTimes;
 	char fileName[kMaxNameSize];
-	int *year, *month, *day, *hour;
-	double *Rain;
-	double tempo;
-	char *tmpstr;
-	
-	tmpstr = rainGauges[num].getFileName();
-    snprintf(fileName,sizeof(fileName),"%s", tmpstr);//WR--09192023: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
-	numParams = rainGauges[num].getParm();
-	numTimes  = rainGauges[num].getTime();
-	
-	cout<<"\nReading RainGauge Data File '";
-	cout<< fileName<<"'..."<<endl<<flush;
+	snprintf(fileName, sizeof(fileName), "%s", rainGauges[num].getFileName());
+
+	cout<<"\nReading RainGauge Data File '"<<fileName<<"'..."<<endl<<flush;
 
 	ifstream readDataFile(fileName);
 	if (!readDataFile) {
 		cout << "\nFile " <<fileName<<" not found!" << endl;
 		cout << "Exiting Program...\n\n"<<endl;
-		exit(2);}
-
-	char paramNames[10];
-	year  = new int[numTimes];
-	month = new int[numTimes];
-	day   = new int[numTimes];
-	hour  = new int[numTimes];
-
-	Rain  = new double[numTimes];
-	
-	for (int cnt = 0; cnt<numParams; cnt++) {
-		readDataFile >> paramNames;
+		exit(2);
 	}
-	
-	for (int count = 0;count<numTimes;count++) {
-		for (int ct = 0;ct<numParams;ct++) {
-			if (ct==0) {
-				readDataFile >> year[count];}
-			else if (ct==1) {
-				readDataFile >> month[count];}
-			else if (ct==2) {
-				readDataFile >> day[count];}
-			else if (ct==3) {
-				readDataFile >> hour[count];
-			}
-			else if (ct==4) {
-				readDataFile >> tempo;
-				if (tempo < 0  || tempo > 200)
-					Rain[count] = 9999.99;
-				else
-					Rain[count] = tempo;
-			}
+
+	// Validate CSV header: Year,Month,Day,Hour,Rain_mm/hr
+	std::string headerLine;
+	std::getline(readDataFile, headerLine);
+	{
+		std::istringstream hss(headerLine);
+		std::string token;
+		int ncols = 0;
+		while (std::getline(hss, token, ',')) ncols++;
+		if (ncols != 5) {
+			cerr << "\nError: Rain gauge data file '" << fileName
+			     << "' header must have 5 columns "
+			        "(Year,Month,Day,Hour,Rain_mm/hr)." << endl;
+			exit(1);
 		}
 	}
 
+	std::vector<int>    Year, Month, Day, Hour;
+	std::vector<double> Rain;
+
+	std::string line;
+	while (std::getline(readDataFile, line)) {
+		if (line.empty()) continue;
+		std::istringstream ss(line);
+		std::string token;
+
+		std::getline(ss, token, ',');
+		Year.push_back(std::stoi(token));
+		std::getline(ss, token, ',');
+		Month.push_back(std::stoi(token));
+		std::getline(ss, token, ',');
+		Day.push_back(std::stoi(token));
+		std::getline(ss, token, ',');
+		Hour.push_back(std::stoi(token));
+		std::getline(ss, token, ',');
+		double tempo = std::stod(token);
+		Rain.push_back((tempo < 0 || tempo > 200) ? 9999.99 : tempo);
+	}
 	readDataFile.close();
-	
-	rainGauges[num].setYear(year);
-	rainGauges[num].setMonth(month);
-	rainGauges[num].setDay(day);
-	rainGauges[num].setHour(hour);
 
-	robustNess(Rain, numTimes);
-	
+	robustNess(Rain.data(), static_cast<int>(Rain.size()));
+
+	rainGauges[num].setYear(Year);
+	rainGauges[num].setMonth(Month);
+	rainGauges[num].setDay(Day);
+	rainGauges[num].setHour(Hour);
 	rainGauges[num].setRain(Rain);
-
-	delete [] Rain; delete [] hour;
-	delete [] year; delete [] month; delete [] day;
-
 }
 
 /***************************************************************************

--- a/src/tRasTin/tRainfall.cpp
+++ b/src/tRasTin/tRainfall.cpp
@@ -454,6 +454,7 @@ void tRainfall::readGaugeStat(char *stationfile)
 	// Validate CSV header: ID,DataFile,Northing,Easting,Elevation
 	std::string headerLine;
 	std::getline(readFile, headerLine);
+	if (!headerLine.empty() && headerLine.back() == '\r') headerLine.pop_back();
 	{
 		std::istringstream hss(headerLine);
 		std::string token;
@@ -471,6 +472,7 @@ void tRainfall::readGaugeStat(char *stationfile)
 	std::vector<std::string> rows;
 	std::string line;
 	while (std::getline(readFile, line)) {
+		if (!line.empty() && line.back() == '\r') line.pop_back();
 		if (!line.empty()) rows.push_back(line);
 	}
 	readFile.close();
@@ -539,6 +541,7 @@ void tRainfall::readGaugeData(int num)
 	// Validate CSV header: Year,Month,Day,Hour,Rain_mm/hr
 	std::string headerLine;
 	std::getline(readDataFile, headerLine);
+	if (!headerLine.empty() && headerLine.back() == '\r') headerLine.pop_back();
 	{
 		std::istringstream hss(headerLine);
 		std::string token;
@@ -557,6 +560,8 @@ void tRainfall::readGaugeData(int num)
 
 	std::string line;
 	while (std::getline(readDataFile, line)) {
+		if (line.empty()) continue;
+		if (line.back() == '\r') line.pop_back();
 		if (line.empty()) continue;
 		std::istringstream ss(line);
 		std::string token;

--- a/src/tSimulator/tPreProcess.cpp
+++ b/src/tSimulator/tPreProcess.cpp
@@ -81,6 +81,8 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 	// SKYnGM2008LU
 	int optluinterp;
 
+	int optevapotrans = 0;
+
 	// Commented out several items for compatibility of existing data sets -VIVA //WR reverted 08282023
 
     // BEGIN Move tControl Arguments to .in file WR 08282023
@@ -113,7 +115,7 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 		IterReadItem(infile, tempVariable,"WIDTHINTERPOLATION");
 	}
 	
-	IterReadItem(infile, tempVariable,"OPTEVAPOTRANS");   //Options
+	optevapotrans = IterReadItem(infile, optevapotrans, "OPTEVAPOTRANS");   //Options
 	IterReadItem(infile, tempVariable,"OPTINTERCEPT");
 	IterReadItem(infile, tempVariable,"GFLUXOPTION");
 	//IterReadItem(infile, tempVariable,"OPTRUNON");
@@ -226,12 +228,15 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 		CheckFileExists(tempString,"HYDROMETGRID");
 	}
 
-	if (optlu == 1 || optlu == 2) {
-		IterReadItem( infile, tempString,"LUGRID");
-		CheckFileExists(tempString, "LUGRID");
+	if (optevapotrans != 0) {
 		IterReadItem(infile, tempVariable, "CENTROIDLAT");
 		IterReadItem(infile, tempVariable, "CENTROIDLONG");
 		IterReadItem(infile, tempVariable, "UTCOFFSET");
+	}
+
+	if (optlu == 1 || optlu == 2) {
+		IterReadItem(infile, tempString, "LUGRID");
+		CheckFileExists(tempString, "LUGRID");
 	}
 
 	// SKY2008Snow from AJR2007

--- a/src/tSimulator/tPreProcess.cpp
+++ b/src/tSimulator/tPreProcess.cpp
@@ -226,10 +226,12 @@ void tPreProcess::CheckInputFile(tInputFile &infile)
 		CheckFileExists(tempString,"HYDROMETGRID");
 	}
 
-	// SKYnGM2008LU: added by AJR 2007
-	if (optlu == 1) {
+	if (optlu == 1 || optlu == 2) {
 		IterReadItem( infile, tempString,"LUGRID");
 		CheckFileExists(tempString, "LUGRID");
+		IterReadItem(infile, tempVariable, "CENTROIDLAT");
+		IterReadItem(infile, tempVariable, "CENTROIDLONG");
+		IterReadItem(infile, tempVariable, "UTCOFFSET");
 	}
 
 	// SKY2008Snow from AJR2007


### PR DESCRIPTION
This pull request standardizes all text-based input files to CSV format with descriptive headers, targeting the v6.0.0 release. It also removes several legacy input options that have been unused in practice and simplifies the hydromet input chain.

## Scientific / Physical Changes

* **Humidity input:** Removed support for dew temperature (TD) and vapor pressure (VP) as humidity inputs. Relative humidity (RH) is now the only accepted humidity format. Dew temperature and vapor pressure are computed internally from RH.
* **Net radiation column removed:** The optional net radiation (NR) column in the hydromet station data file was removed entirely. While this was optional before the variable if provided was never actually used. Only the calculated NR was used.
* **Pan evaporation Kpan removed:** The pan coefficient (`Kpan`) is no longer read or applied. Users must pre-apply their pan coefficient before providing ET data to the model.
* **Basin centroid coordinates moved to `.in` file:** Latitude, longitude, and UTC offset used for solar angle calculations are no longer read per-station from the SDF. They are now required as global keywords (`CENTROIDLAT`, `CENTROIDLONG`, `UTCOFFSET`) in the main input file whenever ET is enabled (`OPTEVAPOTRANS != 0`). 
  
## Technical Changes (C++ / Inputs)
  
* **`tRainGauge` refactored:** Replaced raw pointer arrays (`int *year`, `double *rain`, etc.) with `std::vector`. Removed `numTimes`/`numParams` members; size is now derived from vector length.
* **`tHydroMet` refactored:** Replaced all raw pointer arrays with `std::vector`. Destructor simplified to `= default`. Removed `numTimes` member; `getTime()` now returns `year.size()`. Removed `setTime()`, `setNetRad()`, `getNetRad()`, `setDewTemp()`, `getDewTemp()`, `setVaporPress()`, `getVaporPress()`, `setGmt()`, `getGmt()`, per-station `setLat(double,int)` / `getLat(int)`, and per-station `setLong(double,int)` / `getLong(int)`.
* **`tEvapoTrans` cleaned up:** Removed members `vapOption`, `dewHumFlag`, `coeffPan`, `gridlat`, `gridlong`, `gridgmt`, `nrOption`, `netRad`. Removed `netradiation`, `dewtemperature`, and `vaporpressure` tVariant objects. Removed TD and VP handling from `createVariant()` and `resampleGrids()`.
* **Fixed 10-column hydromet MDF:** Station met data files are now exactly 10 columns (or 5 for pan ET). Column 10 is either surface temperature (`TS`) or incoming solar (`IS`), detected from the header name.
* **Binary restart updated:** All removed members are removed from `writeRestart`/`readRestart` in both `tEvapoTrans` and `tHydroMet`.
* **Line Endings:** Strip trailing \r from all text file reads to handle CRLF line endings, common issue when input files are created or edited on Windows before being transferred to Linux/macOS.
* **Fix gridded meteorological data (tsOption):** `IS` and `TS` grids now correctly set `tsOption` at initialization, making the gridded radiation path consistent with the station path.
* **Fix station surface temperature input:** observed `TS` from station data was read but never applied to the node for use in the energy balance (`Tso`). Now consistent with how gridded `TS` has always worked.
  
## New `.in` File Keywords
  
| Keyword | Description | Required When |
| :--- | :--- | :--- |
| `CENTROIDLAT` | Basin centroid latitude (decimal degrees) | `OPTEVAPOTRANS != 0` |
| `CENTROIDLONG` | Basin centroid longitude (decimal degrees) | `OPTEVAPOTRANS != 0` |
| `UTCOFFSET` | UTC offset (integer hours, e.g. `-7`) | `OPTEVAPOTRANS != 0` | 
> [!NOTE]
> These keywords are for  solar position calculations, not the adjusting input time series.

## Input File Format Reference
  
All text input files now use CSV with a required header row. Files are validated at startup, column count mismatches exit with an error message.
  
  ```csv
  Rain Gauge Station File (*.sdf)

  ID,DataFile,Northing,Easting,Elevation
  1,data/gauge1.mdf,395479.11,3889526.15,2188.46

  Rain Gauge Data File (*.mdf)

  Year,Month,Day,Hour,Rain_mm/hr
  2010,1,1,0,0.0

  Hydromet Station File (*.sdf)

  ID,DataFile,Northing,Easting,Elevation
  1,data/weather/station1.mdf,395479.11,3889526.15,2188.46

  Hydromet Station Data File (*.mdf): Calculated ET from Penman-Monteith

Column 10 header must be either IS (incoming solar radiation, W/m²) or TS (surface temperature, °C). Use 9999.99 for unavailable variables, the model will interpolate from neighboring valid values.

  Year,Month,Day,Hour,PA_mb,RH_pct,XC_tenths,US_m/s,TA_C,IS_W/m2
  2010,1,1,0,860.0,65.0,3.0,2.1,5.2,250.0

  or

  Year,Month,Day,Hour,PA_mb,RH_pct,XC_tenths,US_m/s,TA_C,TS_C
  2010,1,1,0,860.0,65.0,3.0,2.1,5.2,4.8

  Hydromet Station Data File (*.mdf): Pan ET (OPTEVAPOTRANS=2)

  Year,Month,Day,Hour,ET_mm/hr
  2010,1,1,0,0.12

  Hydromet Grid Data File (*.gdf)

Valid parameter codes: PA, RH, XC, US, TA, TS, IS. Use NO_DATA for both columns when a variable is not available.

  Variable,BasePath,FileExtension
  PA,data/grids/pressure,asc
  RH,data/grids/humidity,asc
  XC,NO_DATA,NO_DATA
  US,data/grids/wind,asc
  TA,data/grids/airtemp,asc
  TS,NO_DATA,NO_DATA
  IS,data/grids/solar,asc

  Soil Table (*.sdt)

  12 columns: ID + 11 soil properties.
  
  ID,Ks_mm/hr,ThetaS_m3/m3,ThetaR_m3/m3,m_[],PsiB_cm,f_1/mm,As_[],Au_[],n_m3/m3,ks_J/msK,Cs_J/m3K
  1,10.5,0.45,0.05,0.3,180.0,2.5,1.0,1.0,0.45,1.0,1.2e6

  Land Use Table (*.ldt)

  13 columns: ID + 12 land use properties (Gray model parameters removed in v6.0.0).

  ID,ThroughFall,CanopyStorage_mm,DrainCoeff,DrainExp,Albedo,VegHeight_m,OptTransmCoeff,StomRes_s/m,VegFraction,LAI,EvapThresh,TransThresh
  1,0.7,10.0,0.002,3.0,0.12,2.5,0.4,200.0,0.8,2.5,0.2,0.5

  Soil / Land Use Grid Data File (*.gdf)

  Variable,BasePath,FileExtension
  Ks,data/grids/Ks,asc