### PR TITLE
feature: Add Rootzone Depth as Land Use Parameter

### DIFF
--- a/doc/md/CHANGELOG.md
+++ b/doc/md/CHANGELOG.md
@@ -16,6 +16,7 @@ v6.0.0 is a major release focused on simplifying the user experience and streaml
 * **Snow Outputs:** Added `Snow Depth` and `Snow Density` to standard pixel and dynamic output routines. ([#104](https://github.com/tRIBS-Model/tRIBS/pull/104))
 * **Standardized Hydrologic Outputs:** All output files that report hydrologic variables have been standardized to CSV format with a single header line. ([#114](https://github.com/tRIBS-Model/tRIBS/pull/114))
 * **Standardized Hydrologic Inputs:** All forcing and parameter input files were standardized to CSV format with a single header line. Centorid latitude, longitude, and UTC timezone offset are no longer specified in the station and gridded data files. ([#116](https://github.com/tRIBS-Model/tRIBS/pull/116))
+* **Root Zone Depth:** Previously root zone depth used for determining soil mositure for calculating plant transpiration was hardcoded at 1m. Root zone depth is now a land use parameter that can be provided in the land use table or gridded. Users who do not want to use this feature can specify `9999.99` in the land use table to use the original default of 1m. ([#117](https://github.com/tRIBS-Model/tRIBS/pull/117))
 
 ### Fixed
 * **ET Partitioning:** Fixed a scaling bug in `tEvapoTrans` where unscaled vegetation rates were subtracted from potential ET. ([#107](https://github.com/tRIBS-Model/tRIBS/pull/107))

--- a/doc/md/TODO.md
+++ b/doc/md/TODO.md
@@ -5,7 +5,6 @@
 - [ ] Update flow for reading in dynamic LU grids--this is a bottleneck in terms of speed
 - [ ] Consider flexible approach for specifying outputs, I.E. could we make it so that you could pass in attribute related to a node and have them returned in the dynamic and integrated files. Could also be nice for input parameters, i.e. make list of hard coded parameters and expose as inputs.
 - [ ] Resolve remaing problems in channel transmission losses routine for option 2 & 3, (transient & green-ampt methods) ([#112](https://github.com/tRIBS-Model/tRIBS/pull/112)).
-- [ ] Add root zone depth as land use parameter. If specified to -9999 then use original 1m.
 - [ ] Remove default parallelization option
 - [ ] Port MeshBuilder parallelization workflow into tRIBS
 - [ ] Package METIS from parallelization work with tRIBS
@@ -32,6 +31,7 @@
 - [x] Clean up channel and hillslope routing parameters
 - [x] Simplify humidity input. Only keep RH and remove others
 - [x] Standardize input text files
+- [x] Add root zone depth as land use parameter. If specified to -9999 then use original 1m.
 
 
 

--- a/src/tCNode/tCNode.cpp
+++ b/src/tCNode/tCNode.cpp
@@ -96,6 +96,7 @@ tCNode::tCNode() :tNode()
 	CanFieldCap = DrainCoeff = 0.0;
 	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;
   EvapThresh = TransThresh = 0.0; // CJC2025
+  RootZoneDepth = 1000.0;
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
@@ -105,13 +106,15 @@ tCNode::tCNode() :tNode()
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
   EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
+  RootZoneDepthInPrevGrid = RootZoneDepthInUntilGrid = 1000.0;
 
 	// SKYnGM2008LU
 	AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
   AvEvapThresh = AvTransThresh = 0.0; // CJC2025
-	
+  AvRootZoneDepth = 1000.0;
+
 	// SKY2008Snow from AJR2007
 	//snowpack -- RINEHART 2007 @ NMT
 	liqWEq = iceWEq =  liqRoute = dU = 0.0;
@@ -230,6 +233,7 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	CanFieldCap = DrainCoeff = 0.0;
 	DrainExpPar = OptTransmCoeff = LeafAI = 0.0;
   EvapThresh = TransThresh = 0.0; // CJC2025
+  RootZoneDepth = 1000.0;
 
 	// SKYnGM2008LU
 	LandUseAlbInPrevGrid = LandUseAlbInUntilGrid = ThroughFallInPrevGrid = ThroughFallInUntilGrid = 0.0;
@@ -239,12 +243,14 @@ tCNode::tCNode(tInputFile &infile) :tNode() {
 	DrainCoeffInPrevGrid = DrainCoeffInUntilGrid = DrainExpParInPrevGrid = DrainExpParInUntilGrid = 0.0;
 	OptTransmCoeffInPrevGrid = OptTransmCoeffInUntilGrid = LeafAIInPrevGrid = LeafAIInUntilGrid = 0.0;
   EvapThreshInPrevGrid = EvapThreshInUntilGrid = TransThreshInPrevGrid = TransThreshInUntilGrid = 0.0; // CJC2025
+  RootZoneDepthInPrevGrid = RootZoneDepthInUntilGrid = 1000.0;
 
 	// SKYnGM2008LU
 	AvThroughFall = AvCanFieldCap = 0.0;
 	AvDrainCoeff = AvDrainExpPar = AvLandUseAlb = AvVegHeight = 0.0;
 	AvOptTransmCoeff = AvStomRes = AvVegFraction = AvLeafAI = 0.0;
   AvEvapThresh = AvTransThresh = 0.0; // CJC2025
+  AvRootZoneDepth = 1000.0;
 
 	// SKY2008Snow from AJR2007
 	//snowpack -- RINEHART 2007 @ NMT
@@ -463,6 +469,7 @@ double tCNode::getLeafAI() {return LeafAI;}
 // CJC2025: New Parameters
 double tCNode::getEvapThresh() {return EvapThresh;}
 double tCNode::getTransThresh() {return TransThresh;}
+double tCNode::getRootZoneDepth() {return RootZoneDepth;}
 
 // SKYnGM2008LU
 double tCNode::getLandUseAlbInPrevGrid() {return LandUseAlbInPrevGrid;}
@@ -486,10 +493,12 @@ double tCNode::getOptTransmCoeffInUntilGrid() {return OptTransmCoeffInUntilGrid;
 double tCNode::getLeafAIInPrevGrid() {return LeafAIInPrevGrid;}
 double tCNode::getLeafAIInUntilGrid() {return LeafAIInUntilGrid;}
 // CJC2025: New Parameters
-double tCNode::getEvapThreshInPrevGrid() {return EvapThreshInPrevGrid;} 
-double tCNode::getEvapThreshInUntilGrid() {return EvapThreshInUntilGrid;} 
-double tCNode::getTransThreshInPrevGrid() {return TransThreshInPrevGrid;} 
-double tCNode::getTransThreshInUntilGrid() {return TransThreshInUntilGrid;} 
+double tCNode::getEvapThreshInPrevGrid() {return EvapThreshInPrevGrid;}
+double tCNode::getEvapThreshInUntilGrid() {return EvapThreshInUntilGrid;}
+double tCNode::getTransThreshInPrevGrid() {return TransThreshInPrevGrid;}
+double tCNode::getTransThreshInUntilGrid() {return TransThreshInUntilGrid;}
+double tCNode::getRootZoneDepthInPrevGrid() {return RootZoneDepthInPrevGrid;}
+double tCNode::getRootZoneDepthInUntilGrid() {return RootZoneDepthInUntilGrid;} 
 
 // SKYnGM2008LU
 double tCNode::getAvThroughFall() {return AvThroughFall;}
@@ -505,6 +514,7 @@ double tCNode::getAvLeafAI() {return AvLeafAI;}
 // CJC2025: New Parameters
 double tCNode::getAvEvapThresh() {return AvEvapThresh;}
 double tCNode::getAvTransThresh() {return AvTransThresh;}
+double tCNode::getAvRootZoneDepth() {return AvRootZoneDepth;}
 
 int    tCNode::getFloodStatus()  { return flood; }
 int    tCNode::getSoilID()       { return soiID; }
@@ -804,6 +814,7 @@ void tCNode::setLeafAI(double value) { LeafAI = value; }
 // CJC2025: New Parameters
 void tCNode::setEvapThresh(double value) { EvapThresh = value; }
 void tCNode::setTransThresh(double value) { TransThresh = value; }
+void tCNode::setRootZoneDepth(double value) { RootZoneDepth = value; }
 
 // SKYnGM2008LU
 void tCNode::setLandUseAlbInPrevGrid(double value) { LandUseAlbInPrevGrid = value; }
@@ -831,6 +842,8 @@ void tCNode::setEvapThreshInPrevGrid(double value) { EvapThreshInPrevGrid = valu
 void tCNode::setEvapThreshInUntilGrid(double value) { EvapThreshInUntilGrid = value; }
 void tCNode::setTransThreshInPrevGrid(double value) { TransThreshInPrevGrid = value; }
 void tCNode::setTransThreshInUntilGrid(double value) { TransThreshInUntilGrid = value; }
+void tCNode::setRootZoneDepthInPrevGrid(double value) { RootZoneDepthInPrevGrid = value; }
+void tCNode::setRootZoneDepthInUntilGrid(double value) { RootZoneDepthInUntilGrid = value; }
 
 // SKYnGM2008LU
 void tCNode::setAvThroughFall(double value) { AvThroughFall = value; }
@@ -846,6 +859,7 @@ void tCNode::setAvLeafAI(double value) { AvLeafAI = value; }
 // CJC2025: New Parameters
 void tCNode::setAvEvapThresh(double value) { AvEvapThresh = value; }
 void tCNode::setAvTransThresh(double value) { AvTransThresh = value; }
+void tCNode::setAvRootZoneDepth(double value) { AvRootZoneDepth = value; }
 
 // Added by Giuseppe Mascaro in 2016 to allow ingestion of soil grids
 void tCNode::setKs(double value) { Ks = value;}
@@ -1352,6 +1366,7 @@ void tCNode::writeRestart(fstream& rStr) const
   // CJC2025: New Parameters
   BinaryWrite(rStr, EvapThresh);
   BinaryWrite(rStr, TransThresh);
+  BinaryWrite(rStr, RootZoneDepth);
 
   BinaryWrite(rStr, LandUseAlbInPrevGrid);
   BinaryWrite(rStr, LandUseAlbInUntilGrid);
@@ -1378,6 +1393,8 @@ void tCNode::writeRestart(fstream& rStr) const
   BinaryWrite(rStr, EvapThreshInUntilGrid);
   BinaryWrite(rStr, TransThreshInPrevGrid);
   BinaryWrite(rStr, TransThreshInUntilGrid);
+  BinaryWrite(rStr, RootZoneDepthInPrevGrid);
+  BinaryWrite(rStr, RootZoneDepthInUntilGrid);
 
   BinaryWrite(rStr, AvThroughFall);
   BinaryWrite(rStr, AvCanFieldCap);
@@ -1392,6 +1409,7 @@ void tCNode::writeRestart(fstream& rStr) const
   // CJC2025: New Parameters
   BinaryWrite(rStr, AvEvapThresh);
   BinaryWrite(rStr, AvTransThresh);
+  BinaryWrite(rStr, AvRootZoneDepth);
 
   BinaryWrite(rStr, cumHrsSun); // Snow
   BinaryWrite(rStr, cumLHF);
@@ -1624,6 +1642,7 @@ void tCNode::readRestart(fstream& rStr)
   // CJC2025: New Parameters
   BinaryRead(rStr, EvapThresh);
   BinaryRead(rStr, TransThresh);
+  BinaryRead(rStr, RootZoneDepth);
 
   BinaryRead(rStr, LandUseAlbInPrevGrid);
   BinaryRead(rStr, LandUseAlbInUntilGrid);
@@ -1650,6 +1669,8 @@ void tCNode::readRestart(fstream& rStr)
   BinaryRead(rStr, EvapThreshInUntilGrid);
   BinaryRead(rStr, TransThreshInPrevGrid);
   BinaryRead(rStr, TransThreshInUntilGrid);
+  BinaryRead(rStr, RootZoneDepthInPrevGrid);
+  BinaryRead(rStr, RootZoneDepthInUntilGrid);
 
   BinaryRead(rStr, AvThroughFall);
   BinaryRead(rStr, AvCanFieldCap);
@@ -1664,6 +1685,7 @@ void tCNode::readRestart(fstream& rStr)
   // CJC2025: New Parameters
   BinaryRead(rStr, AvEvapThresh);
   BinaryRead(rStr, AvTransThresh);
+  BinaryRead(rStr, AvRootZoneDepth);
 
   BinaryRead(rStr, cumHrsSun); // Snow
   BinaryRead(rStr, cumLHF);
@@ -1868,6 +1890,7 @@ void tCNode::printVariables()
   // CJC2025: New Parameters
   cout << " EvapThresh " << EvapThresh;
   cout << " TransThresh " << TransThresh;
+  cout << " RootZoneDepth " << RootZoneDepth;
 
   cout << " LandUseAlbInPrevGrid " << LandUseAlbInPrevGrid;
   cout << " LandUseAlbInUntilGrid " << LandUseAlbInUntilGrid;

--- a/src/tCNode/tCNode.h
+++ b/src/tCNode/tCNode.h
@@ -254,6 +254,7 @@ public:
   // CJC2025: New Parameters
   double getEvapThresh();
   double getTransThresh();
+  double getRootZoneDepth();
 
   // SKYnGM2008LU
   double getLandUseAlbInPrevGrid();
@@ -281,6 +282,8 @@ public:
   double getEvapThreshInUntilGrid();
   double getTransThreshInPrevGrid();
   double getTransThreshInUntilGrid();
+  double getRootZoneDepthInPrevGrid();
+  double getRootZoneDepthInUntilGrid();
 
 
 
@@ -298,6 +301,7 @@ public:
   // CJC2025: New Parameters
   double getAvEvapThresh();
   double getAvTransThresh();
+  double getAvRootZoneDepth();
 
   double getAvSoilMoisture();         // Integral characteristics
   double getAvEvapFract();
@@ -448,6 +452,7 @@ public:
   // CJC2025: New Parameters
   void setEvapThresh(double);
   void setTransThresh(double);
+  void setRootZoneDepth(double);
 
   void setLandUseAlbInPrevGrid(double);
   void setLandUseAlbInUntilGrid(double);
@@ -474,6 +479,8 @@ public:
   void setEvapThreshInUntilGrid(double);
   void setTransThreshInPrevGrid(double);
   void setTransThreshInUntilGrid(double);
+  void setRootZoneDepthInPrevGrid(double);
+  void setRootZoneDepthInUntilGrid(double);
 
   // SKYnGM2008LU
   void setAvThroughFall(double);
@@ -489,6 +496,7 @@ public:
   // CJC2025: New Parameters
   void setAvEvapThresh(double);
   void setAvTransThresh(double);
+  void setAvRootZoneDepth(double);
 
   void setAvSoilMoisture(double);     // Integral characteristics
   void setAvEvapFract(double);
@@ -788,6 +796,7 @@ protected:
   // CJC2025: New Parameters
   double EvapThresh;
   double TransThresh;
+  double RootZoneDepth;
 
   // SKYnGM2008LU
   double LandUseAlbInPrevGrid, LandUseAlbInUntilGrid, ThroughFallInPrevGrid, ThroughFallInUntilGrid;
@@ -797,12 +806,14 @@ protected:
   double DrainCoeffInPrevGrid, DrainCoeffInUntilGrid, DrainExpParInPrevGrid, DrainExpParInUntilGrid;
   double OptTransmCoeffInPrevGrid, OptTransmCoeffInUntilGrid, LeafAIInPrevGrid, LeafAIInUntilGrid;
   double EvapThreshInPrevGrid, EvapThreshInUntilGrid, TransThreshInPrevGrid, TransThreshInUntilGrid; // CJC2025: New Parameters
+  double RootZoneDepthInPrevGrid, RootZoneDepthInUntilGrid;
 
   // SKYnGM2008LU
   double AvThroughFall, AvCanFieldCap;
   double AvDrainCoeff, AvDrainExpPar, AvLandUseAlb, AvVegHeight;
   double AvOptTransmCoeff, AvStomRes, AvVegFraction, AvLeafAI;
   double AvEvapThresh, AvTransThresh; // CJC2025: New Parameters
+  double AvRootZoneDepth;
 
   double AvSoilMoisture;        // Integral characteristics
   double AvEvapFract;

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -847,7 +847,7 @@ void tEvapoTrans::setCoeffs(tCNode* cNode)
 	// CJC2025: Set the values for the stress thresholds from the table.
     coeffSE = landPtr->getLandProp(11);
     coeffST = landPtr->getLandProp(12);
-    {
+    if (luOption == 0) {
         double rzDepth = landPtr->getLandProp(13);
         if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
         rzDepth = std::max(rzDepth, 100.0);
@@ -3268,7 +3268,7 @@ void tEvapoTrans::readHydroMetGrid(char *gridFile)
 ** Reads a file (*.gdf) from LUGRID keyword containing the base names of 
 ** the various input land use parameter grids along with the extension
 ** used for the filename. These follow a string that identifies the line
-** with the parameters (ie. AL,TF,VH,SR,VF,CC,DC,DE,OT,LA). If no data 
+** with the parameters (ie. AL,TF,VH,SR,VF,CC,DC,DE,OT,LA,SE,ST,RZ). If no data
 ** available for any parameters, the string NO_DATA should be input 
 ** instead of the path name and extension name. In this version, a single
 ** value of latitude, longitude and GMT is used for entire grids. The
@@ -3356,9 +3356,10 @@ void tEvapoTrans::readLUGrid(char *gridFile)
 		  		(strcmp(LUgridParamNames[ct],"OT")!=0) &&
 		  		(strcmp(LUgridParamNames[ct],"LA")!=0) &&
                 (strcmp(LUgridParamNames[ct],"SE")!=0) &&
-                (strcmp(LUgridParamNames[ct],"ST")!=0) ) {
+                (strcmp(LUgridParamNames[ct],"ST")!=0) &&
+                (strcmp(LUgridParamNames[ct],"RZ")!=0) ) {
 			Cout << "\nA land use parameter name in the LU gdf file is an unexpected one."<<endl;
-			Cout << "\nExpected variables: AL,TF,VH,SR,VF,CC,DC,DE,OT,LA,SE or ST" << endl;
+			Cout << "\nExpected variables: AL,TF,VH,SR,VF,CC,DC,DE,OT,LA,SE,ST or RZ" << endl;
 			Cout << "\tCheck and re-run the program" << endl;
 			Cout << "\nExiting Program..."<<endl<<endl;
 			exit(1);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -849,7 +849,7 @@ void tEvapoTrans::setCoeffs(tCNode* cNode)
     coeffST = landPtr->getLandProp(12);
     {
         double rzDepth = landPtr->getLandProp(13);
-        if (rzDepth >= 9999.99) rzDepth = 1000.0;
+        if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
         rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
         cNode->setRootZoneDepth(rzDepth);
     }
@@ -3758,9 +3758,7 @@ void tEvapoTrans::newLUGridData(tCNode * cNode)
 			coeffST = cNode->getTransThresh();
 		}
 		if (strcmp(LUgridParamNames[ct],"RZ")==0) {
-			double rzDepth = cNode->getRootZoneDepth();
-			if (rzDepth >= 9999.99) rzDepth = 1000.0;
-			rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
+			double rzDepth = std::min(cNode->getRootZoneDepth(), cNode->getBedrockDepth());
 			cNode->setRootZoneDepth(rzDepth);
 		}
 	}
@@ -4385,7 +4383,7 @@ void tEvapoTrans::interpolateLUGrids(tCNode* cNode)
 								(double(RZgridhours[NowTillWhichRZgrid]) - double(RZgridhours[NowTillWhichRZgrid - 1]));
 		}
 		else { rzDepth = cNode->getRootZoneDepthInPrevGrid(); }
-		if (rzDepth >= 9999.99) rzDepth = 1000.0;
+		if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; }
 		rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
 		cNode->setRootZoneDepth(rzDepth);
 	}
@@ -4455,7 +4453,7 @@ void tEvapoTrans::constantLUGrids(tCNode* cNode)
         if ( (strcmp(LUgridParamNames[ct],"RZ")==0))
         {
             double rzDepth = cNode->getRootZoneDepthInPrevGrid();
-            if (rzDepth >= 9999.99) rzDepth = 1000.0;
+            if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; }
             rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
             cNode->setRootZoneDepth(rzDepth);
         }

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -72,6 +72,7 @@ tEvapoTrans::tEvapoTrans()
 	LeafAIGrid = nullptr;
     EvapThreshGrid = nullptr; // CJC2025
     TransThreshGrid = nullptr; // CJC2025
+    RootZoneDepthGrid = nullptr;
 	ALgridhours = nullptr;
 	TFgridhours = nullptr;
 	VHgridhours = nullptr;
@@ -84,6 +85,7 @@ tEvapoTrans::tEvapoTrans()
 	LAgridhours = nullptr;
 	SEgridhours = nullptr; // CJC2025
 	STgridhours = nullptr; // CJC2025
+	RZgridhours = nullptr;
 	ALgridFileNames = nullptr;
 	TFgridFileNames = nullptr;
 	VHgridFileNames = nullptr;
@@ -96,6 +98,7 @@ tEvapoTrans::tEvapoTrans()
 	LAgridFileNames = nullptr;
 	SEgridFileNames = nullptr; // CJC2025
 	STgridFileNames = nullptr; // CJC2025
+	RZgridFileNames = nullptr;
 
 	gridPtr = nullptr; 	nParmLU = 0;
 }
@@ -142,6 +145,7 @@ tEvapoTrans::tEvapoTrans(SimulationControl *simCtrPtr, tMesh<tCNode> *gridRef,
 	LeafAIGrid = nullptr;
     EvapThreshGrid = nullptr; // CJC2025
     TransThreshGrid = nullptr; // CJC2025
+    RootZoneDepthGrid = nullptr;
 	ALgridhours = nullptr;
 	TFgridhours = nullptr;
 	VHgridhours = nullptr;
@@ -843,6 +847,12 @@ void tEvapoTrans::setCoeffs(tCNode* cNode)
 	// CJC2025: Set the values for the stress thresholds from the table.
     coeffSE = landPtr->getLandProp(11);
     coeffST = landPtr->getLandProp(12);
+    {
+        double rzDepth = landPtr->getLandProp(13);
+        if (rzDepth >= 9999.99) rzDepth = 1000.0;
+        rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
+        cNode->setRootZoneDepth(rzDepth);
+    }
 
     if (coeffV >= 1.0) //prevents loss of snow when unloaded from canopy WR 05/12/2024
         coeffV = 0.99;
@@ -3543,6 +3553,12 @@ void tEvapoTrans::createVariantLU()
 			SetGridTimeInfoVariables(TransThreshGrid, LUgridParamNames[ct]);
 			TransThreshGrid->newVariable(LUgridParamNames[ct]);
 		}
+		if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+			RootZoneDepthGrid = new tVariant(gridPtr,respPtr);
+			RootZoneDepthGrid->setFileNames(LUgridBaseNames[ct], LUgridExtNames[ct]);
+			SetGridTimeInfoVariables(RootZoneDepthGrid, LUgridParamNames[ct]);
+			RootZoneDepthGrid->newVariable(LUgridParamNames[ct]);
+		}
 	}
 }
 
@@ -3604,6 +3620,9 @@ void tEvapoTrans::createStaticVariantLU()
         } else if (paramName == "ST") {
             TransThreshGrid = new tVariant(gridPtr, respPtr);
             TransThreshGrid->updateLUVarOfPrevGrid("ST", staticFileName);
+        } else if (paramName == "RZ") {
+            RootZoneDepthGrid = new tVariant(gridPtr, respPtr);
+            RootZoneDepthGrid->updateLUVarOfPrevGrid("RZ", staticFileName);
         }
     }
 
@@ -3732,11 +3751,17 @@ void tEvapoTrans::newLUGridData(tCNode * cNode)
 			coeffLAI = cNode->getLeafAI(); // SKY2008Snow
 		}
 		// CJC2025: New parameters
-		if (strcmp(LUgridParamNames[ct],"SE")==0) {			
+		if (strcmp(LUgridParamNames[ct],"SE")==0) {
 			coeffSE = cNode->getEvapThresh();
 		}
-		if (strcmp(LUgridParamNames[ct],"ST")==0) {			
+		if (strcmp(LUgridParamNames[ct],"ST")==0) {
 			coeffST = cNode->getTransThresh();
+		}
+		if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+			double rzDepth = cNode->getRootZoneDepth();
+			if (rzDepth >= 9999.99) rzDepth = 1000.0;
+			rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
+			cNode->setRootZoneDepth(rzDepth);
 		}
 	}
 
@@ -3984,6 +4009,21 @@ void tEvapoTrans::initialLUGridAssignment()
         }
       }
     }
+    if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+      if ( (timer->getCurrentTime())>(double(RZgridhours[NowTillWhichRZgrid])) && numRZfiles > 1 ) {
+	while ( (timer->getCurrentTime())>(double(RZgridhours[NowTillWhichRZgrid])) ) {
+	  NowTillWhichRZgrid++;
+	}
+	RootZoneDepthGrid->updateLUVarOfBothGrids("RZ", RZgridFileNames[NowTillWhichRZgrid]);
+	RootZoneDepthGrid->updateLUVarOfPrevGrid("RZ", RZgridFileNames[NowTillWhichRZgrid-1]);
+      }
+      else {
+        RootZoneDepthGrid->updateLUVarOfPrevGrid("RZ", RZgridFileNames[1]);
+        if (luInterpOption == 1) {
+            RootZoneDepthGrid->updateLUVarOfBothGrids("RZ", RZgridFileNames[1]);
+        }
+      }
+    }
   } // end for loop
 
   }
@@ -4168,6 +4208,20 @@ void tEvapoTrans::LUGridAssignment()
 	    }
       }
     }
+    if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+      if (numRZfiles <= 1) continue;
+      if (NowTillWhichRZgrid<=numRZfiles) {
+	    if ((timer->getCurrentTime())>(double(RZgridhours[NowTillWhichRZgrid]))) {
+	      NowTillWhichRZgrid++;
+	      if ((NowTillWhichRZgrid-1)<numRZfiles) {
+	        RootZoneDepthGrid->updateLUVarOfBothGrids("RZ", RZgridFileNames[NowTillWhichRZgrid]);
+	      }
+	      else {
+	        RootZoneDepthGrid->updateLUVarOfPrevGrid("RZ", RZgridFileNames[numRZfiles]);
+	      }
+	    }
+      }
+    }
   }
 }
 
@@ -4319,6 +4373,22 @@ void tEvapoTrans::interpolateLUGrids(tCNode* cNode)
 								(double(STgridhours[NowTillWhichSTgrid]) - double(STgridhours[NowTillWhichSTgrid - 1])));
 		}
 	}
+	if (strcmp(LUgridParamNames[ct], "RZ") == 0) {
+		double rzDepth;
+		if (NowTillWhichRZgrid > numRZfiles) {
+			rzDepth = cNode->getRootZoneDepthInPrevGrid();
+		}
+		else if ((NowTillWhichRZgrid > 1) && (NowTillWhichRZgrid <= numRZfiles)) {
+			rzDepth = cNode->getRootZoneDepthInPrevGrid() +
+								(cNode->getRootZoneDepthInUntilGrid() - cNode->getRootZoneDepthInPrevGrid()) *
+								(timer->getCurrentTime() - double(RZgridhours[NowTillWhichRZgrid - 1])) /
+								(double(RZgridhours[NowTillWhichRZgrid]) - double(RZgridhours[NowTillWhichRZgrid - 1]));
+		}
+		else { rzDepth = cNode->getRootZoneDepthInPrevGrid(); }
+		if (rzDepth >= 9999.99) rzDepth = 1000.0;
+		rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
+		cNode->setRootZoneDepth(rzDepth);
+	}
   } // end for loop
   
   return;
@@ -4381,6 +4451,13 @@ void tEvapoTrans::constantLUGrids(tCNode* cNode)
         if ( (strcmp(LUgridParamNames[ct],"ST")==0))
         {
             cNode->setTransThresh( cNode->getTransThreshInPrevGrid() );
+        }
+        if ( (strcmp(LUgridParamNames[ct],"RZ")==0))
+        {
+            double rzDepth = cNode->getRootZoneDepthInPrevGrid();
+            if (rzDepth >= 9999.99) rzDepth = 1000.0;
+            rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
+            cNode->setRootZoneDepth(rzDepth);
         }
     } // end for loop
 
@@ -4469,9 +4546,15 @@ void tEvapoTrans::integratedLUVars(tCNode* cNode, double te){
       else if (te > 1.0)
 	cNode->setAvTransThresh((cNode->getAvTransThresh()*(te-1.0) + cNode->getTransThresh())/te);
     }
+    if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+      if (fabs(te - 1.0) < 1.0E-6)
+	cNode->setAvRootZoneDepth(cNode->getRootZoneDepth());
+      else if (te > 1.0)
+	cNode->setAvRootZoneDepth((cNode->getAvRootZoneDepth()*(te-1.0) + cNode->getRootZoneDepth())/te);
+    }
   }
-  
-  return; 
+
+  return;
 }
 
 /***************************************************************************
@@ -4504,6 +4587,7 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 	else if (strcmp(LUgridParamName,"LA")==0) {numLAfiles = 0;}
     else if (strcmp(LUgridParamName,"SE")==0) {numSEfiles = 0;} // CJC2025
     else if (strcmp(LUgridParamName,"ST")==0) {numSTfiles = 0;} // CJC2025
+    else if (strcmp(LUgridParamName,"RZ")==0) {numRZfiles = 0;}
 
 	numFilesCounter = 0;
 	currentTimeLU = 0;
@@ -4532,6 +4616,7 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 			else if (strcmp(LUgridParamName,"LA")==0) {numLAfiles++;}
             else if (strcmp(LUgridParamName,"SE")==0) {numSEfiles++;} // <<< ADDED
             else if (strcmp(LUgridParamName,"ST")==0) {numSTfiles++;} // <<< ADDED
+            else if (strcmp(LUgridParamName,"RZ")==0) {numRZfiles++;}
 
 			numFilesCounter++;
 		}
@@ -4662,6 +4747,13 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 			STgridFileNames[ct]=new char[kName];
 		}
 	}
+    else if (strcmp(LUgridParamName,"RZ")==0) {
+		RZgridhours = new int [numRZfiles+1];
+		RZgridFileNames = new char*[numRZfiles+1];
+		for (int ct=0;ct<numRZfiles+1;ct++) {
+			RZgridFileNames[ct]=new char[kName];
+		}
+	}
 
 	tempgridhours = new int [numFilesCounter+1];
 	tempgridhours[0]=0;
@@ -4733,6 +4825,10 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 				STgridhours[GridHourCounter]=currentTimeLU;
 				strcpy(STgridFileNames[GridHourCounter],VariantLU->fileIn);
 			}
+            else if (strcmp(LUgridParamName,"RZ")==0) {
+				RZgridhours[GridHourCounter]=currentTimeLU;
+				strcpy(RZgridFileNames[GridHourCounter],VariantLU->fileIn);
+			}
 			
 			tempgridhours[GridHourCounter]=currentTimeLU;
 
@@ -4768,6 +4864,7 @@ void tEvapoTrans::SetGridTimeInfoVariables(tVariant *VariantLU, char *LUgridPara
 	else if (strcmp(LUgridParamName,"LA")==0) {NowTillWhichLAgrid = 1;}
     else if (strcmp(LUgridParamName,"SE")==0) {NowTillWhichSEgrid = 1;} // CJC2025
     else if (strcmp(LUgridParamName,"ST")==0) {NowTillWhichSTgrid = 1;} // CJC2025
+    else if (strcmp(LUgridParamName,"RZ")==0) {NowTillWhichRZgrid = 1;}
 
 	return;
 
@@ -4880,8 +4977,16 @@ void tEvapoTrans::deleteLUGrids()
 	  }
 	  delete [] STgridFileNames;
 	}
+    if (strcmp(LUgridParamNames[ct],"RZ")==0) {
+	  delete RootZoneDepthGrid;
+	  delete [] RZgridhours;
+	  for (int sz=0;sz<numRZfiles+1;sz++) {
+	    delete [] RZgridFileNames[sz];
+	  }
+	  delete [] RZgridFileNames;
+	}
   }
-  
+
   for (int sz=0;sz<nParmLU;sz++) {
     delete [] LUgridParamNames[sz];
     delete [] LUgridBaseNames[sz];

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -850,6 +850,7 @@ void tEvapoTrans::setCoeffs(tCNode* cNode)
     {
         double rzDepth = landPtr->getLandProp(13);
         if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
+        rzDepth = std::max(rzDepth, 100.0);
         rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
         cNode->setRootZoneDepth(rzDepth);
     }
@@ -3758,7 +3759,8 @@ void tEvapoTrans::newLUGridData(tCNode * cNode)
 			coeffST = cNode->getTransThresh();
 		}
 		if (strcmp(LUgridParamNames[ct],"RZ")==0) {
-			double rzDepth = std::min(cNode->getRootZoneDepth(), cNode->getBedrockDepth());
+			double rzDepth = std::max(cNode->getRootZoneDepth(), 100.0);
+			rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
 			cNode->setRootZoneDepth(rzDepth);
 		}
 	}
@@ -4384,6 +4386,7 @@ void tEvapoTrans::interpolateLUGrids(tCNode* cNode)
 		}
 		else { rzDepth = cNode->getRootZoneDepthInPrevGrid(); }
 		if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; }
+		rzDepth = std::max(rzDepth, 100.0);
 		rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
 		cNode->setRootZoneDepth(rzDepth);
 	}
@@ -4454,6 +4457,7 @@ void tEvapoTrans::constantLUGrids(tCNode* cNode)
         {
             double rzDepth = cNode->getRootZoneDepthInPrevGrid();
             if (rzDepth >= 9999.99) { rzDepth = 1000.0; } else { rzDepth *= 1000.0; }
+            rzDepth = std::max(rzDepth, 100.0);
             rzDepth = std::min(rzDepth, cNode->getBedrockDepth());
             cNode->setRootZoneDepth(rzDepth);
         }

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -210,24 +210,29 @@ class tEvapoTrans
   tVariant *CanFieldCapGrid, *DrainCoeffGrid;
   tVariant *DrainExpParGrid, *OptTransmCoeffGrid, *LeafAIGrid;
   tVariant *EvapThreshGrid, *TransThreshGrid; // CJC2025
+  tVariant *RootZoneDepthGrid;
 
   // SKYnGM2008LU
   int numALfiles{}, numTFfiles{}, numVHfiles{}, numSRfiles{};
   int numVFfiles{}, numCCfiles{};
   int numDCfiles{}, numDEfiles{}, numOTfiles{}, numLAfiles{};
   int numSEfiles{}, numSTfiles{}; // CJC2025
+  int numRZfiles{};
   int *ALgridhours, *TFgridhours, *VHgridhours, *SRgridhours;
   int *VFgridhours, *CCgridhours;
   int *DCgridhours, *DEgridhours, *OTgridhours, *LAgridhours;
   int *SEgridhours, *STgridhours; // CJC2025
+  int *RZgridhours;
   int NowTillWhichALgrid{}, NowTillWhichTFgrid{}, NowTillWhichVHgrid{}, NowTillWhichSRgrid{};
   int NowTillWhichVFgrid{}, NowTillWhichCCgrid{};
   int NowTillWhichDCgrid{}, NowTillWhichDEgrid{}, NowTillWhichOTgrid{}, NowTillWhichLAgrid{};
   int NowTillWhichSEgrid{}, NowTillWhichSTgrid{}; // CJC2025
+  int NowTillWhichRZgrid{};
   char **ALgridFileNames, **TFgridFileNames, **VHgridFileNames, **SRgridFileNames;
   char **VFgridFileNames, **CCgridFileNames;
   char **DCgridFileNames, **DEgridFileNames, **OTgridFileNames, **LAgridFileNames;
   char **SEgridFileNames, **STgridFileNames; // CJC2025
+  char **RZgridFileNames;
   int AtFirstTimeStepLUFlag{};
 
   int skycover_flag; // intended for when nodata is set for XC gridded data so that skycover is estimated.

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -118,12 +118,6 @@ void tHydroModel::SetHydroMVariables(tInputFile &infile,
 	} else {
 		surfaceSoilDepth = 100.0; // Default to 100mm
 	}
-	if (infile.IsItemIn( "ROOTZONEDEPTH" )) {
-		rootZoneDepth = infile.ReadItem(rootZoneDepth, "ROOTZONEDEPTH");
-	} else {
-		rootZoneDepth = 1000.0; // Default to 1000mm
-	}
-
 	// If a decision made to keep the state vars don't change anything,
 	// keep vars from previous run. Otherwise, re-initialize everything
 	if ( !keep )
@@ -441,6 +435,12 @@ void tHydroModel::InitSet(tResample *resamp)
 		// CJC2025 Stress Thresholds
 		SE_LU   = landPtr->getLandProp(11);
 		ST_LU   = landPtr->getLandProp(12);
+		RZ_LU   = landPtr->getLandProp(13);
+		if (RZ_LU >= 9999.99) RZ_LU = 1000.0;
+		RZ_LU   = std::min(RZ_LU, bedRock);
+		cn->setRootZoneDepth(RZ_LU);
+		cn->setRootZoneDepthInPrevGrid(RZ_LU);
+		cn->setRootZoneDepthInUntilGrid(RZ_LU);
 		cn->setLandUseAlb(Al_LU);
 		cn->setLandUseAlbInPrevGrid(Al_LU);
 		cn->setLandUseAlbInUntilGrid(Al_LU);
@@ -491,13 +491,12 @@ void tHydroModel::InitSet(tResample *resamp)
 		cn->setFlowVelocity(0.0);
 
 		cn->setSoilMoisture(ComputeSurfSoilMoist(surfaceSoilDepth));
-		cn->setRootMoisture(ComputeSurfSoilMoist(rootZoneDepth));
+		cn->setRootMoisture(ComputeSurfSoilMoist(RZ_LU));
 		cn->setSoilMoistureSC(cn->getSoilMoisture()/Ths);
 		cn->setRootMoistureSC(cn->getRootMoisture()/Ths);
 
-        // beta debug, set soil and root cutoff// TODO replace 100.0 and 1000.0 w/ variables for root zone and bedrock
         cn->setSoilCutoff(get_Upper_Moist(surfaceSoilDepth,bedRock)/surfaceSoilDepth); // volumetric soil moisture content of soil zone if water table reaches bedrock
-        cn->setRootCutoff(get_Upper_Moist(rootZoneDepth,bedRock)/rootZoneDepth);// volumetric soil moisture content of root zone if water table reaches bedrock
+        cn->setRootCutoff(get_Upper_Moist(RZ_LU,bedRock)/RZ_LU); // volumetric soil moisture content of root zone if water table reaches bedrock
 
 
 
@@ -575,6 +574,10 @@ void tHydroModel::InitIntegralVars()
 		// CJC2025 Stress Thresholds
 		SE_LU  = landPtr->getLandProp(11);
 		ST_LU  = landPtr->getLandProp(12);
+		RZ_LU  = landPtr->getLandProp(13);
+		if (RZ_LU >= 9999.99) RZ_LU = 1000.0;
+		RZ_LU  = std::min(RZ_LU, cn->getBedrockDepth());
+		cn->setAvRootZoneDepth(RZ_LU);
 		cn->setAvThroughFall(P_LU);
 		cn->setAvCanFieldCap(S_LU);
 		cn->setAvDrainCoeff(K_LU);
@@ -2079,10 +2082,16 @@ void tHydroModel::UnSaturatedZone(double dt)
 		cn->setAvSoilMoisture(floor((BB*AA + ThSurf/Ths)/(AA+1)*1.0E+4));
 
 		// Estimate average root soil moisture
-		ThSurf = ComputeSurfSoilMoist(rootZoneDepth);
-		cn->setRootMoisture( ThSurf );
-		cn->setRootMoistureSC( ThSurf/Ths );
-		cn->addAvSoilMoisture((Mdelt*AA + ThSurf/Ths)/(AA+1.0)*1.0E-1);
+		{
+			double rzDepth = cn->getRootZoneDepth();
+			if (rzDepth >= 9999.99) rzDepth = 1000.0;
+			rzDepth = std::min(rzDepth, DtoBedrock);
+			ThSurf = ComputeSurfSoilMoist(rzDepth);
+			cn->setRootMoisture( ThSurf );
+			cn->setRootMoistureSC( ThSurf/Ths );
+			cn->setRootCutoff( get_Upper_Moist(rzDepth, DtoBedrock) / rzDepth );
+		}
+		cn->addAvSoilMoisture((Mdelt*AA + cn->getRootMoisture()/Ths)/(AA+1.0)*1.0E-1);
 
 		// Set other variables
 		cn->setRecharge((NwtNew-NwtOld)*Ths/(Cos*dt));
@@ -3523,10 +3532,16 @@ void tHydroModel::SaturatedZone(double dtGW)
 		cn->setAvSoilMoisture(floor((BB*AA + ThSurf/Ths)/(AA+1)*1.0E+4));
 
 		// Estimate average root soil moisture
-		ThSurf = ComputeSurfSoilMoist(rootZoneDepth);
-		cn->setRootMoisture( ThSurf );
-		cn->setRootMoistureSC( ThSurf/Ths );
-		cn->addAvSoilMoisture((Mdelt*AA + ThSurf/Ths)/(AA+1.0)*1.0E-1);
+		{
+			double rzDepth = cn->getRootZoneDepth();
+			if (rzDepth >= 9999.99) rzDepth = 1000.0;
+			rzDepth = std::min(rzDepth, DtoBedrock);
+			ThSurf = ComputeSurfSoilMoist(rzDepth);
+			cn->setRootMoisture( ThSurf );
+			cn->setRootMoistureSC( ThSurf/Ths );
+			cn->setRootCutoff( get_Upper_Moist(rzDepth, DtoBedrock) / rzDepth );
+		}
+		cn->addAvSoilMoisture((Mdelt*AA + cn->getRootMoisture()/Ths)/(AA+1.0)*1.0E-1);
 
 		cn->setRecharge((NwtNew-NwtOld)*Ths/(Cos*dtGW));
 		// The following are in [M^3]
@@ -4492,6 +4507,7 @@ void tHydroModel::writeRestart(fstream & rStr) const
   BinaryWrite(rStr, LAI_LU);
   BinaryWrite(rStr, SE_LU);
   BinaryWrite(rStr, ST_LU);
+  BinaryWrite(rStr, RZ_LU);
 
 }
 
@@ -4588,6 +4604,7 @@ void tHydroModel::readRestart(fstream & rStr)
   BinaryRead(rStr, LAI_LU);
   BinaryRead(rStr, SE_LU);
   BinaryRead(rStr, ST_LU);
+  BinaryRead(rStr, RZ_LU);
 }
 
 //=========================================================================

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -439,6 +439,7 @@ void tHydroModel::InitSet(tResample *resamp)
 
 		// Handle Rootzone Depth Input
 		if (RZ_LU >= 9999.99) { RZ_LU = 1000.0; } else { RZ_LU *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
+		RZ_LU   = std::max(RZ_LU, 100.0);
 		RZ_LU   = std::min(RZ_LU, bedRock);
 
 		cn->setRootZoneDepth(RZ_LU);
@@ -581,6 +582,7 @@ void tHydroModel::InitIntegralVars()
 
 		// Handle Rootzone Depth Input
 		if (RZ_LU >= 9999.99) { RZ_LU = 1000.0; } else { RZ_LU *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
+		RZ_LU  = std::max(RZ_LU, 100.0);
 		RZ_LU  = std::min(RZ_LU, cn->getBedrockDepth());
 
 		cn->setAvRootZoneDepth(RZ_LU);

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -2091,9 +2091,7 @@ void tHydroModel::UnSaturatedZone(double dt)
 
 		// Estimate average root soil moisture
 		{
-			double rzDepth = cn->getRootZoneDepth();
-			if (rzDepth >= 9999.99) rzDepth = 1000.0;
-			rzDepth = std::min(rzDepth, DtoBedrock);
+			double rzDepth = std::min(cn->getRootZoneDepth(), DtoBedrock);
 			ThSurf = ComputeSurfSoilMoist(rzDepth);
 			cn->setRootMoisture( ThSurf );
 			cn->setRootMoistureSC( ThSurf/Ths );
@@ -3541,9 +3539,7 @@ void tHydroModel::SaturatedZone(double dtGW)
 
 		// Estimate average root soil moisture
 		{
-			double rzDepth = cn->getRootZoneDepth();
-			if (rzDepth >= 9999.99) rzDepth = 1000.0;
-			rzDepth = std::min(rzDepth, DtoBedrock);
+			double rzDepth = std::min(cn->getRootZoneDepth(), DtoBedrock);
 			ThSurf = ComputeSurfSoilMoist(rzDepth);
 			cn->setRootMoisture( ThSurf );
 			cn->setRootMoistureSC( ThSurf/Ths );

--- a/src/tHydro/tHydroModel.cpp
+++ b/src/tHydro/tHydroModel.cpp
@@ -436,8 +436,11 @@ void tHydroModel::InitSet(tResample *resamp)
 		SE_LU   = landPtr->getLandProp(11);
 		ST_LU   = landPtr->getLandProp(12);
 		RZ_LU   = landPtr->getLandProp(13);
-		if (RZ_LU >= 9999.99) RZ_LU = 1000.0;
+
+		// Handle Rootzone Depth Input
+		if (RZ_LU >= 9999.99) { RZ_LU = 1000.0; } else { RZ_LU *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
 		RZ_LU   = std::min(RZ_LU, bedRock);
+
 		cn->setRootZoneDepth(RZ_LU);
 		cn->setRootZoneDepthInPrevGrid(RZ_LU);
 		cn->setRootZoneDepthInUntilGrid(RZ_LU);
@@ -575,8 +578,11 @@ void tHydroModel::InitIntegralVars()
 		SE_LU  = landPtr->getLandProp(11);
 		ST_LU  = landPtr->getLandProp(12);
 		RZ_LU  = landPtr->getLandProp(13);
-		if (RZ_LU >= 9999.99) RZ_LU = 1000.0;
+
+		// Handle Rootzone Depth Input
+		if (RZ_LU >= 9999.99) { RZ_LU = 1000.0; } else { RZ_LU *= 1000.0; } // If user's rootzone depth is no data (9999.99) set to 1m default
 		RZ_LU  = std::min(RZ_LU, cn->getBedrockDepth());
+
 		cn->setAvRootZoneDepth(RZ_LU);
 		cn->setAvThroughFall(P_LU);
 		cn->setAvCanFieldCap(S_LU);

--- a/src/tHydro/tHydroModel.h
+++ b/src/tHydro/tHydroModel.h
@@ -189,6 +189,7 @@ private:
   // CJC2025 Stress Thresholds
   double ST_LU{};
   double SE_LU{};
+  double RZ_LU{};
 
   // SKY2008Snow from AJR2007
   double snowMeltEx{};
@@ -198,7 +199,6 @@ private:
   double TotMoist{}; 			// Cumulative change in moisture storage
   double DtoBedrock{}; 			// Depth to bedrock
   double surfaceSoilDepth; // Depth for surface soil moisture [mm]
-  double rootZoneDepth;    // Depth for root zone moisture [mm]
   
   ofstream fctout;
   double fSoi100{}, fTop100{}, fClm100{}, fGW100{}, dM100{}, dMRt{}, mTh100{}, mThRt{};

--- a/src/tInOut/tOutput.cpp
+++ b/src/tInOut/tOutput.cpp
@@ -360,7 +360,8 @@ void tOutput<tSubNode>::CreateAndOpenPixel()
 				<<"OptTransmCoeff_[],"
 				<<"StomRes_s_m,"       //80
 				<<"VegFraction[],"
-				<<"LeafAI_[]"          //82
+				<<"LeafAI_[],"
+				<<"RootZoneDepth_m"    //83
 				<<"\n";
 				
 				pixinfo[i].setf( ios::right, ios::adjustfield );
@@ -1064,7 +1065,9 @@ void tCOutput<tSubNode>::WritePixelInfo( double time )
 				<< this->uzel[i]->getOptTransmCoeff() << ","
 				/* 80 */ << this->uzel[i]->getStomRes() << ","
 				<< this->uzel[i]->getVegFraction() << ","
-				<< this->uzel[i]->getLeafAI() << "\n" << flush;
+				<< this->uzel[i]->getLeafAI() << ","
+				/* 83 */ << this->uzel[i]->getRootZoneDepth() <<
+				"\n" << flush; 
 
 			}
 		}
@@ -1342,7 +1345,8 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
 		   << "VolHeatCond" << ','                            // 70
 		   << "SoilHeatCap" << ','                            // 71
 		   << "SoilID" << ','                                 // 72
-		   << "LandUseID"                                     // 73
+		   << "LandUseID" << ','                              // 73
+		   << "AvRootZoneDepth"                               // 74
 		   << "\n";
 	
 	cn = ni.FirstP();
@@ -1477,7 +1481,8 @@ void tCOutput<tSubNode>::WriteIntegrVars( double time )
            << setprecision(7) << cn->getVolHeatCond() << ','  //70
            << setprecision(7) << cn->getSoilHeatCap() << ','  //71
            << setprecision(7) << cn->getSoilID() << ','       //72
-           << setprecision(7) << cn->getLandUse();            //73
+           << setprecision(7) << cn->getLandUse() << ','      //73
+           << setprecision(7) << cn->getAvRootZoneDepth();    //74
 
         intofs<<"\n";
 		

--- a/src/tRasTin/tInvariant.cpp
+++ b/src/tRasTin/tInvariant.cpp
@@ -625,7 +625,7 @@ GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 		id++;
 	}
 	
-	const int kLandColumns = 13; // ID + 12 land use properties
+	const int kLandColumns = 14; // ID + 13 land use properties
 	ifstream Inp0(landTable);
 	if (!Inp0) {
 		cout <<"\nFile "<<landTable<<" not found!"<<endl;
@@ -641,7 +641,7 @@ GenericLandData::GenericLandData(tMesh<tCNode> *mesh,
 		if (c == ',') ++colCount;
 	if (colCount != kLandColumns) {
 		cout << "\nError: Land use table '" << landTable << "' has " << colCount
-		     << " columns, expected " << kLandColumns << " (ID + 12 parameters)." << endl;
+		     << " columns, expected " << kLandColumns << " (ID + 13 parameters)." << endl;
 		cout << "Exiting Program...\n\n" << endl;
 		exit(2);
 	}
@@ -725,7 +725,7 @@ void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 	}
 	
 	infile.ReadItem(landTable, "LANDTABLENAME"); // Input table
-	const int kLandColumns = 13; // ID + 12 land use properties
+	const int kLandColumns = 14; // ID + 13 land use properties
 	ifstream Inp0(landTable);
 	if (!Inp0) {
 		cout <<"File "<<landTable<<" not found!!!"<<endl;
@@ -741,7 +741,7 @@ void GenericLandData::SetLtypeParameters(tMesh<tCNode> *mesh,
 		if (c == ',') ++colCount;
 	if (colCount != kLandColumns) {
 		cout << "\nError: Land use table '" << landTable << "' has " << colCount
-		     << " columns, expected " << kLandColumns << " (ID + 12 parameters)." << endl;
+		     << " columns, expected " << kLandColumns << " (ID + 13 parameters)." << endl;
 		cout << "Exiting Program...\n\n" << endl;
 		exit(2);
 	}

--- a/src/tRasTin/tVariant.cpp
+++ b/src/tRasTin/tVariant.cpp
@@ -231,9 +231,12 @@ void tVariant::updateLUVarOfPrevGrid(const char *param, char *GridFileName)
 			cn->setTransThreshInPrevGrid( resample[id] );
 			cn->setTransThresh( resample[id] );
 		}
+		else if (strcmp(param,"RZ") == 0) {
+			cn->setRootZoneDepthInPrevGrid( resample[id] );
+		}
 
 		cn = nodeIter.NextP();
-		id++; 
+		id++;
 	}
 	return;
 }
@@ -323,10 +326,13 @@ void tVariant::updateLUVarOfBothGrids(const char *param, char *GridFileName)
 			cn->setTransThresh( cn->getTransThreshInUntilGrid() );
 			cn->setTransThreshInUntilGrid( resample[id] );
 		}
-
+		else if (strcmp(param,"RZ") == 0) {
+			cn->setRootZoneDepthInPrevGrid( cn->getRootZoneDepthInUntilGrid() );
+			cn->setRootZoneDepthInUntilGrid( resample[id] );
+		}
 
 		cn = nodeIter.NextP();
-		id++; 
+		id++;
 	}
 	return;
 }


### PR DESCRIPTION
This pull request merges changes implementing per-land-use and spatially variable rootzone depth into the main branch, targeting the upcoming v6.0.0 release.

The primary goal is to replace the optional basin-wide `ROOTZONEDEPTH` input file keyword with a spatially distributed rootzone depth that can be specified either per land use class (land use lookup table) or as a raster (time-varying or static). The global `ROOTZONEDEPTH` keyword is removed entirely. This allows rootzone depth to vary across land cover types and evolve over time, improving the physical realism of the transpiration stress computation. A nodata value of `9999.99` (meters) in the table or raster falls back to the original 1m default. Rootzone depth is enforced per-node as `surfaceSoilDepth ≤ rootZoneDepth ≤ bedrockDepth`.

## Technical Changes (C++ / Inputs)

**Land use table:** Add rootzone depth as column 13 (RZ) of the land use lookup table. Values are specified in meters, a nodata value of `9999.99` reverts to the original hardcoded value of 1m.
  **`tCNode`:** Add per-node state members `RootZoneDepth`, `RootZoneDepthInPrevGrid`, `RootZoneDepthInUntilGrid`, and `AvRootZoneDepth` with full getters and setters.

**`tHydroModel`:** Remove the `ROOTZONEDEPTH` input keyword and the single basin-wide `rootZoneDepth` member. Initialization now reads column 13 from the land use table per node. `RootCutoff` (the wilting point threshold used in `betaFuncT()`) is now recomputed each timestep inside both the unsaturated and saturated zone loops, so time-varying raster inputs are reflected immediately in the transpiration stress calculation.

**`tEvapoTrans`:**
* Add `RootZoneDepthGrid` (`tVariant*`) and the associated tracking variables (`numRZfiles`, `RZgridhours`, `NowTillWhichRZgrid`, `RZgridFileNames`) following the existing `EvapThreshGrid`/`TransThreshGrid` pattern.
* Add param code `"RZ"` to all land use grid functions: `readLUGrid`, `createVariantLU`, `createStaticVariantLU`, `initialLUGridAssignment`, `LUGridAssignment`, `interpolateLUGrids`, `constantLUGrids`, `integratedLUVars`, and the destructor.

**`tVariant`:** Add `"RZ"` handling to `updateLUVarOfPrevGrid()` and `updateLUVarOfBothGrids()`. The raw raster value (meters) is stored in `InPrevGrid`/`InUntilGrid`. Unit conversion and clamping are applied in `constantLUGrids`/`interpolateLUGrids` when the value is written to the active `RootZoneDepth`.

## Input/Output Specification
  
The following keyword is no longer valid in the main input file and should be removed from existing input files:
* `ROOTZONEDEPTH` - basin-wide rootzone depth

The following `.gdf` parameter code is now valid for `OPTLANDUSE = 1` or `2`:
* `RZ` - rootzone depth raster (values in meters)

The land use lookup table now requires **13 columns** (previously 12). The new column 13 is rootzone depth in meters. The simulation will exit and warn the user if the table does not contain 13 columns.

## Output File Changes

* **`.pixel` files** now contain **83 columns** (previously 82). Column 83 is `RootZoneDepth` (mm), the instantaneous per-node rootzone depth at each output timestep.
* **Integrated spatial output (`.int`)** now contains **74 columns** (previously 73). Column 74 is `AvRootZoneDepth` (mm), the time-averaged rootzone depth over the simulation, consistent with how all other dynamic land use parameters are reported.