### PR TITLE
Fix/met data station reading

### DIFF
--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -3126,12 +3126,12 @@ void tEvapoTrans::readHydroMetData(int num)
 
 	// Verify enough data exists to cover the full simulation duration
 	{
-		int requiredSteps = static_cast<int>(std::round(timer->getEndTime() / timer->getEtIStep()));
+		int requiredSteps = static_cast<int>(std::round(timer->getEndTime() / timer->getMetStep()));
 		if (static_cast<int>(rows.size()) < requiredSteps) {
 			std::cerr << "\n\nFATAL ERROR in " << fileName << std::endl;
 			std::cerr << "Insufficient data for simulation duration." << std::endl;
 			std::cerr << "Required: " << requiredSteps << " timesteps ("
-			          << timer->getEndTime() << " hrs at " << timer->getEtIStep() << " hr intervals)" << std::endl;
+			          << timer->getEndTime() << " hrs at " << timer->getMetStep() << " hr intervals)" << std::endl;
 			std::cerr << "Available after start date: " << rows.size() << " timesteps" << std::endl;
 			std::cerr << "Exiting Program...\n\n" << std::endl;
 			exit(1);

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -484,7 +484,7 @@ void tEvapoTrans::initializeVariables()
 	ha2700 = 0.0; ha2925 = 0.0;
 	ha3150 = 0.0; ha3375 = 0.0;
 
-	hourlyTimeStep = 0; thisStation = 0; oldTimeStep = 0;
+	hourlyTimeStep = 0; thisStation = 0;
 	tsOption = 0;
 	
 	currentTime = new int[4];
@@ -534,15 +534,16 @@ void tEvapoTrans::assignStationToNode()
 ** tEvapoTrans::setTime() Function
 **
 ***************************************************************************/
-void tEvapoTrans::setTime(int time)
+void tEvapoTrans::setTime()
 {
 	// Get current calendar time
 	if (metdataOption == 1) {
-		currentTime[0] = weatherStations[0].getYear(time); 
+		int time = currentMetIndex();
+		currentTime[0] = weatherStations[0].getYear(time);
 		currentTime[1] = weatherStations[0].getMonth(time);
 		currentTime[2] = weatherStations[0].getDay(time);
 		currentTime[3] = weatherStations[0].getHour(time);
-		
+
 		// Obtain current hour
 		nodeHour = timer->hour;
 	}
@@ -551,11 +552,34 @@ void tEvapoTrans::setTime(int time)
 		currentTime[1] = timer->month;
 		currentTime[2] = timer->day;
 		currentTime[3] = timer->hour;
-		
+
 		// Obtain current hour
 		nodeHour = timer->hour;
 	}
 	}
+
+/***************************************************************************
+**
+** tEvapoTrans::currentMetIndex() Function
+**
+** Returns the station met record corresponding to the current simulation
+** time. Station forcing is stored at METSTEP cadence, so the record index
+** is the number of elapsed met steps -- NOT the ET/I step counter. This
+** keeps sub-metstep ET/I/snow timesteps reading the same met record within
+** a met interval instead of marching past the end of the series. The series
+** is trimmed to STARTDATE on read, so this is also restart-safe (currentTime
+** is 0 at the start). The clamp guards the final timestep landing exactly on
+** endTime (index == series length).
+**
+***************************************************************************/
+int tEvapoTrans::currentMetIndex() const
+{
+	int idx = timer->getElapsedMETSteps(timer->getCurrentTime());
+	int n   = weatherStations[0].getTime();
+	if (idx < 0)   idx = 0;
+	if (idx >= n)  idx = n - 1;
+	return idx;
+}
 
 
 //=========================================================================
@@ -572,8 +596,8 @@ void tEvapoTrans::setTime(int time)
 ***************************************************************************/
 void tEvapoTrans::SetEnvironment() {
 
-    // Set time variables ('hourlyTimeStep' is a 'tEvapoTrans' variable)
-    setTime(hourlyTimeStep);
+    // Set calendar/time variables from the current met record (see currentMetIndex)
+    setTime();
 
     // Compute Sun variables for given hour (basin average,
     // although spatially distributed variables can be easily
@@ -731,7 +755,7 @@ void tEvapoTrans::callEvapoPotential()
       	  //updates meteorological variables
           if (metdataOption == 1) {
               thisStation = assignedStation[count];
-              newHydroMetData(hourlyTimeStep); //read in met data from station file -- inherited function
+              newHydroMetData(); //read in met data from station file -- inherited function
 
               if (fabs(skyCover-9999.99)<1.0E-3){ // work around since nodata from grids only set to 9999.99 once in tvariannt
                   skycover_flag =1;
@@ -815,10 +839,8 @@ void tEvapoTrans::callEvapoPotential()
 
 	timeCount++; // bug fixed by Pat - June 2009
 
-	// Assign old time
-	oldTimeStep = hourlyTimeStep;
-	
-	// Update hourly time
+	// Update ET/I step counter (used for snow pack-age timestamps and the
+	// first-step init guard; met records are indexed by time, see currentMetIndex)
 	hourlyTimeStep++;
 	isRestartStart = false;
 	}
@@ -1062,7 +1084,7 @@ void tEvapoTrans::ComputeETComponents(tIntercept *Intercept, tCNode *cNode,
 		// Assign hydromet vars
 		if (metdataOption == 1) {
 			thisStation = assignedStation[count];
-			newHydroMetData(hourlyTimeStep);//AJR 2008 -- CHANGED FROM OLDTIMESTEP TO HOURLYTIMESTEP
+			newHydroMetData();
 		}
 		else if (metdataOption == 2) {
 			newHydroMetGridData(cNode);
@@ -3757,8 +3779,9 @@ void tEvapoTrans::createStaticVariantLU()
 ** nodes based on the results of the tResample Thiessen polygon routine.
 **
 ***************************************************************************/
-void tEvapoTrans::newHydroMetData(int time) 
+void tEvapoTrans::newHydroMetData()
 {
+	int time = currentMetIndex();
 
 	// Obtain values from tHydroMet
 	for (int i=0; i<numStations;i++) {
@@ -3778,7 +3801,7 @@ void tEvapoTrans::newHydroMetData(int time)
 				tsOption = (fabs(inShortR - 9999.99) > 1.0E-3) ? 2 : 0;
 
 
-				if (time == 0) {
+				if (hourlyTimeStep == 0) {
 					Tso = weatherStations[i].getAirTemp(time) + 273.15;
 					Tlo = Tso;
 				}

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -259,10 +259,17 @@ void tEvapoTrans::readRsMonthlyFactors(tInputFile &infile)
 {
 	const int kMonths = 12;
 
+	// Both the tEvapoTrans and tSnowPack objects run this setup, so print the
+	// status line only once (the file is still read into each object's state).
+	static bool rsStatusPrinted = false;
+
 	// The feature is opt-in: keyword absent then keep default diurnal scaling.
 	if (!infile.IsItemIn("RSPARAMFILE")) {
-		Cout << "\nStomatal resistance: no RSPARAMFILE specified; "
-		     << "using default diurnal scaling." << endl;
+		if (!rsStatusPrinted) {
+			Cout << "\nStomatal resistance: no RSPARAMFILE specified; "
+			     << "using default diurnal scaling." << endl;
+			rsStatusPrinted = true;
+		}
 		return;
 	}
 
@@ -312,8 +319,11 @@ void tEvapoTrans::readRsMonthlyFactors(tInputFile &infile)
 	}
 	Inp.close();
 
-	Cout << "\nStomatal resistance: applying monthly scaling factors from '"
-	     << rsParamFile << "'." << endl;
+	if (!rsStatusPrinted) {
+		Cout << "\nStomatal resistance: applying monthly scaling factors from '"
+		     << rsParamFile << "'." << endl;
+		rsStatusPrinted = true;
+	}
 }
 
 /***************************************************************************

--- a/src/tHydro/tEvapoTrans.cpp
+++ b/src/tHydro/tEvapoTrans.cpp
@@ -3186,7 +3186,7 @@ void tEvapoTrans::readHydroMetData(int num)
 				int expected_mo = mo[count-1];
 				int expected_dy = dy[count-1];
 				int expected_hr = hr[count-1];
-				expected_hr += timer->getEtIStep();
+				expected_hr += timer->getMetStep();
 				while (expected_hr >= 24) {
 					expected_hr -= 24;
 					expected_dy++;

--- a/src/tHydro/tEvapoTrans.h
+++ b/src/tHydro/tEvapoTrans.h
@@ -58,12 +58,13 @@ class tEvapoTrans
   void assignStationToNode();
   void resampleGrids(tRunTimer *);
   void setCoeffs(tCNode *);
-  void setTime(int);
+  void setTime();
+  int  currentMetIndex() const; // station met record for the current sim time
   void readHydroMetData(int);
   void readHydroMetStat(char*);
   void readHydroMetGrid(char*);
   void readLUGrid(char*); // SKYnGM2008LU: added by AJR 2007
-  void newHydroMetData(int);
+  void newHydroMetData();
   void newHydroMetGridData(tCNode *);
   void newLUGridData(tCNode *); // SKYnGM2008LU: added by AJR 2007
   void createVariant();
@@ -145,7 +146,7 @@ class tEvapoTrans
   int snowOption{}; // NEW FOR SNOW.... SKY2008Snow from AJR2007
   int shelterOption{}; // NEW FOR SHELTERING... SKY2008Snow from AJR2007
   int gFluxOption{}, ID{};
-  int gmt{}, nodeHour{}, thisStation{}, oldTimeStep{};
+  int gmt{}, nodeHour{}, thisStation{};
   int numStations{}, arraySize{}, hourlyTimeStep{}, nParm{};
   bool isRestartStart{false};
   int tsOption{};

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -426,7 +426,7 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
         //updates meteorological variables if not in stochastic mode
         if (metdataOption == 1) {
             thisStation = assignedStation[count];
-            newHydroMetData(hourlyTimeStep); //read in met data from station file -- inherited function
+            newHydroMetData(); //read in met data from station file -- inherited function
 
             if (fabs(skyCover-9999.99)<1.0E-3){ // assumed if first value is 9999.99 the rest are
                 skycover_flag =1;
@@ -862,7 +862,6 @@ void tSnowPack::callSnowPack(tIntercept *Intercept, int flag) {
 
     }//end while-nodes
     timeCount++;
-    oldTimeStep = hourlyTimeStep;
     hourlyTimeStep++;
     isRestartStart = false;
 }

--- a/src/tHydro/tSnowPack.cpp
+++ b/src/tHydro/tSnowPack.cpp
@@ -1187,20 +1187,22 @@ void tSnowPack::setToNodeSnP(tCNode *node) {
     }
 
     if (snWE > 1e-5) {
-        persMaxtemp += 1.0;
+        // Accumulate persistence in hours (timeSteph = etistep) rather than in
+        // integration-step counts, so the diagnostic is timestep-independent.
+        persMaxtemp += timeSteph;
 
         if (persMaxtemp > persMax) {
             persMax = persMaxtemp;
 
-            if (persMaxtemp - 1 < 1)
-                inittimeTemp = hourlyTimeStep;
+            if (persMaxtemp - timeSteph < timeSteph) // first step of this pack
+                inittimeTemp = hourlyTimeStep * timeSteph; // elapsed hours
 
         }
     }
 
     if (snWE >= peakSnWE) {
         peakSnWE = snWE;
-        peaktime = hourlyTimeStep;
+        peaktime = hourlyTimeStep * timeSteph; // elapsed hours
         inittime = inittimeTemp;
     }
 
@@ -1371,7 +1373,7 @@ double tSnowPack::drainageCalc(double liqWE_m, double snDepth_m, double rho, dou
     // Flux = K_sat * (S_eff)^3, 3 is a theoretical value from Colbeck
     double drainage_flux_mps = kSatRef * S_eff * S_eff * S_eff;
 
-    // Since timestep is hardcoded to 1 hour, Flux (m/hr) = Volume (m)
+    // Integrate the flux (m/s) over the timestep (dt_sec) to a volume (m).
     double route_vol = drainage_flux_mps * dt_sec;
 
     // Mass Balance Limit


### PR DESCRIPTION
Fixes several issues that surfaced when running with sub-hourly rainfall (e.g. 15-min) against hourly meteorological forcing. Simulations ran but produced `NaN` ET partway through, and certain snow timing outputs variables would save incorrectly.
Previously this configuration was rarely used (forcing is almost always hourly), so these latent bugs went unnoticed. 

The most important piece of these changes is the switch from the counter-based indexing to using the actual time-based accessor in the meteorological code. This brings this section code to be more in-line with how the rainfall data is ingested.

## Technical Changes (C++ / Inputs)
  
**Met indexing (time-based access)**
- Replaced counter-based met indexing with a single time-based accessor, `tEvapoTrans::currentMetIndex()` = `clamp(getElapsedMETSteps(currentTime), 0, n-1)`.
- `setTime()` and `newHydroMetData()` now resolve the record from simulation time internally (no `int time` argument). All station met reads go through one path.
- `hourlyTimeStep` retained only for its legitimate uses (snow pack-age timestamps, first-step init guard); removed dead `oldTimeStep`.
    
**Snow timing diagnostics (timestep-independent)**
- Snow persistence and pack-timing diagnostics now accumulate in hours (`+= timeSteph`, `hourlyTimeStep × timeSteph`) instead of integration-step counts, so `PersTimeMax` / `InitPackTime` / `PeakPackTime` are correct under sub-hourly steps. These are output-only — no effect on SWE/melt/depth/density physics.
- Stomatal-resistance status line no longer prints twice (both `tEvapoTrans` and `tSnowPack` run the same setup); reads still populate each object's state.